### PR TITLE
[Feat/#3] 온보딩플로우 UI 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/src/assets/logo_s.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>이어드림</title>
+    <!-- 카카오 SDK -->
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,14 +4,23 @@ import {
   Route,
   Navigate,
 } from "react-router-dom";
+import { useEffect } from "react";
 import LoginPage from "./pages/LoginPage";
 import HomePage from "./pages/HomePage";
 import WriteNewsPage from "./pages/WriteNewsPage";
 import NewsBoxPage from "./pages/NewsBoxPage";
 import MyPage from "./pages/MyPage";
 import SplashPage from "./pages/SplashPage";
+import TutorialPage from "./pages/TutorialPage";
+import ProtectedRoute from "./components/common/ProtectedRoute";
+import { initKakao } from "./services/kakaoAuth";
 
 function App() {
+  useEffect(() => {
+    // 앱 시작 시 카카오 SDK 초기화
+    initKakao();
+  }, []);
+
   return (
     <Router>
       <div className="App">
@@ -19,10 +28,39 @@ function App() {
           <Route path="/" element={<SplashPage />} />
           <Route path="/splash" element={<SplashPage />} />
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/home" element={<HomePage />} />
-          <Route path="/write-news" element={<WriteNewsPage />} />
-          <Route path="/news-box" element={<NewsBoxPage />} />
-          <Route path="/mypage" element={<MyPage />} />
+          <Route path="/tutorial" element={<TutorialPage />} />
+          <Route
+            path="/home"
+            element={
+              <ProtectedRoute>
+                <HomePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/write-news"
+            element={
+              <ProtectedRoute>
+                <WriteNewsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/news-box"
+            element={
+              <ProtectedRoute>
+                <NewsBoxPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/mypage"
+            element={
+              <ProtectedRoute>
+                <MyPage />
+              </ProtectedRoute>
+            }
+          />
 
           {/* TODO: 추가 페이지들 구현 후 주석 해제 */}
           {/* <Route path="/signup" element={<SignupPage />} /> */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import TutorialPage from "./pages/TutorialPage";
 import FamilySetupPage from "./pages/FamilySetupPage";
 import FamilyCreatePage from "./pages/FamilyCreatePage";
 import FamilyJoinPage from "./pages/FamilyJoinPage";
+import FamilySubscribePage from "./pages/FamilySubscribePage";
 import ProtectedRoute from "./components/common/ProtectedRoute";
 import { initKakao } from "./services/kakaoAuth";
 
@@ -35,6 +36,7 @@ function App() {
           <Route path="/family-setup" element={<FamilySetupPage />} />
           <Route path="/family/create" element={<FamilyCreatePage />} />
           <Route path="/family/join" element={<FamilyJoinPage />} />
+          <Route path="/family/subscribe" element={<FamilySubscribePage />} />
           <Route
             path="/home"
             element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,9 @@ import NewsBoxPage from "./pages/NewsBoxPage";
 import MyPage from "./pages/MyPage";
 import SplashPage from "./pages/SplashPage";
 import TutorialPage from "./pages/TutorialPage";
+import FamilySetupPage from "./pages/FamilySetupPage";
+import FamilyCreatePage from "./pages/FamilyCreatePage";
+import FamilyJoinPage from "./pages/FamilyJoinPage";
 import ProtectedRoute from "./components/common/ProtectedRoute";
 import { initKakao } from "./services/kakaoAuth";
 
@@ -29,6 +32,9 @@ function App() {
           <Route path="/splash" element={<SplashPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/tutorial" element={<TutorialPage />} />
+          <Route path="/family-setup" element={<FamilySetupPage />} />
+          <Route path="/family/create" element={<FamilyCreatePage />} />
+          <Route path="/family/join" element={<FamilyJoinPage />} />
           <Route
             path="/home"
             element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import FamilySetupPage from "./pages/FamilySetupPage";
 import FamilyCreatePage from "./pages/FamilyCreatePage";
 import FamilyJoinPage from "./pages/FamilyJoinPage";
 import FamilySubscribePage from "./pages/FamilySubscribePage";
+import PaymentPage from "./pages/PaymentPage";
 import ProtectedRoute from "./components/common/ProtectedRoute";
 import { initKakao } from "./services/kakaoAuth";
 
@@ -37,6 +38,7 @@ function App() {
           <Route path="/family/create" element={<FamilyCreatePage />} />
           <Route path="/family/join" element={<FamilyJoinPage />} />
           <Route path="/family/subscribe" element={<FamilySubscribePage />} />
+          <Route path="/payment" element={<PaymentPage />} />
           <Route
             path="/home"
             element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import FamilyCreatePage from "./pages/FamilyCreatePage";
 import FamilyJoinPage from "./pages/FamilyJoinPage";
 import FamilySubscribePage from "./pages/FamilySubscribePage";
 import PaymentPage from "./pages/PaymentPage";
+import RecipientInfoPage from "./pages/RecipientInfoPage";
+import GettingStartedPage from "./pages/GettingStartedPage";
 import ProtectedRoute from "./components/common/ProtectedRoute";
 import { initKakao } from "./services/kakaoAuth";
 
@@ -39,6 +41,8 @@ function App() {
           <Route path="/family/join" element={<FamilyJoinPage />} />
           <Route path="/family/subscribe" element={<FamilySubscribePage />} />
           <Route path="/payment" element={<PaymentPage />} />
+          <Route path="/recipient" element={<RecipientInfoPage />} />
+          <Route path="/getting-started" element={<GettingStartedPage />} />
           <Route
             path="/home"
             element={

--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../../hooks/useAuth";
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  redirectTo?: string;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  children,
+  redirectTo = "/login",
+}) => {
+  const { isLoggedIn, loading } = useAuth();
+
+  if (loading) {
+    // 로딩 중일 때는 스피너나 로딩 화면을 보여줄 수 있습니다
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">로딩 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isLoggedIn) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { useAuth } from "../../hooks/useAuth";
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -18,6 +19,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { logout } = useAuth();
 
   const isActive = (path: string) => {
     return location.pathname === path;
@@ -117,6 +119,29 @@ const MainLayout: React.FC<MainLayoutProps> = ({
                   <span className="text-xs font-medium">{item.label}</span>
                 </button>
               ))}
+
+              {/* 로그아웃 버튼 */}
+              <button
+                onClick={logout}
+                className="flex flex-col items-center p-2 rounded-xl transition-all duration-300 text-gray-400 hover:text-red-500"
+              >
+                <div className="w-12 h-12 rounded-xl flex items-center justify-center mb-1 transition-all duration-300 hover:bg-red-50">
+                  <svg
+                    className="w-6 h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+                    />
+                  </svg>
+                </div>
+                <span className="text-xs font-medium">로그아웃</span>
+              </button>
             </div>
           </nav>
         )}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect } from "react";
+import type { KakaoUser } from "../types/auth";
+import {
+  checkKakaoLoginStatus,
+  getKakaoUserInfo,
+  logoutFromKakao,
+} from "../services/kakaoAuth";
+
+export const useAuth = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [user, setUser] = useState<KakaoUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    checkLoginStatus();
+  }, []);
+
+  const checkLoginStatus = async () => {
+    try {
+      setLoading(true);
+      const isLoggedInStatus = checkKakaoLoginStatus();
+
+      if (isLoggedInStatus) {
+        const userInfo = await getKakaoUserInfo();
+        setUser(userInfo);
+        setIsLoggedIn(true);
+      } else {
+        setUser(null);
+        setIsLoggedIn(false);
+      }
+    } catch (error) {
+      console.error("로그인 상태 확인 오류:", error);
+      setUser(null);
+      setIsLoggedIn(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const logout = () => {
+    logoutFromKakao();
+    setUser(null);
+    setIsLoggedIn(false);
+  };
+
+  return {
+    isLoggedIn,
+    user,
+    loading,
+    checkLoginStatus,
+    logout,
+  };
+};

--- a/src/pages/FamilyCreatePage.tsx
+++ b/src/pages/FamilyCreatePage.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const FamilyCreatePage: React.FC = () => {
+  const navigate = useNavigate();
+  const [familyName, setFamilyName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isReady = familyName.trim().length > 0;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await handleConfirm();
+  };
+
+  const handleConfirm = async () => {
+    if (!isReady) return;
+    setIsSubmitting(true);
+    try {
+      // TODO: API 연동 (가족 생성) 후 결제 페이지로 이동
+      navigate("/family/subscribe", { state: { familyName } });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+      <div className="relative w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-20 pb-28">
+        {/* 인사 및 안내 문구 */}
+        <div className="mt-32 mb-8">
+          <div className="text-[#018941] font-extrabold text-xl mb-2">
+            안녕하세요!
+          </div>
+          <h1 className="text-3xl font-extrabold leading-snug text-[#2c2c2c] mb-6">
+            새롭게 그룹을 만드시는군요!
+          </h1>
+          <div className="text-2xl text-gray-500 mb-2">
+            가족 이름을 입력해 주세요
+          </div>
+          <div className="text-gray-400">
+            가족 이름은 나중에도 변경할 수 있어요
+          </div>
+        </div>
+
+        {/* 입력 폼 */}
+        <form onSubmit={handleSubmit}>
+          <input
+            type="text"
+            value={familyName}
+            onChange={(e) => setFamilyName(e.target.value)}
+            placeholder="예: 김OO 가족"
+            className="w-full rounded-2xl border border-gray-200 px-5 py-4 text-lg focus:outline-none focus:ring-2 focus:ring-[#018941]"
+            maxLength={30}
+            required
+          />
+          {/* 키보드에서 제출 지원용 숨김 버튼 */}
+          <button type="submit" className="hidden" />
+        </form>
+
+        {/* 하단 확인 버튼 (입력 시 노출) */}
+        {isReady && (
+          <div className="absolute left-0 right-0 bottom-6 px-6 pb-[env(safe-area-inset-bottom)]">
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={isSubmitting}
+              className="w-full bg-[#018941] text-white py-4 rounded-xl font-medium text-lg shadow-md hover:bg-[#016b31] transition-colors"
+            >
+              {isSubmitting ? "확인 중..." : "확인"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FamilyCreatePage;

--- a/src/pages/FamilyJoinPage.tsx
+++ b/src/pages/FamilyJoinPage.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const FamilyJoinPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [inviteCode, setInviteCode] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inviteCode.trim()) return;
+    setIsSubmitting(true);
+    try {
+      // TODO: API 연동 (초대 코드 검증 및 참여)
+      // await api.joinFamily({ inviteCode })
+      navigate("/home");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+      <div className="w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-20 pb-10">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="text-sm text-gray-500 mb-6 hover:text-gray-700"
+        >
+          ← 뒤로가기
+        </button>
+
+        <h1 className="text-2xl font-bold mb-6">가족 참여하기</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label className="block text-sm text-gray-600 mb-2">
+              초대 코드
+            </label>
+            <input
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value)}
+              placeholder="예: ABCD-1234"
+              className="w-full rounded-lg border border-gray-200 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#018941] uppercase tracking-wider"
+              maxLength={32}
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || !inviteCode.trim()}
+            className="w-full bg-[#018941] disabled:opacity-60 text-white py-4 rounded-lg font-medium text-lg hover:bg-[#016b31] transition-colors"
+          >
+            {isSubmitting ? "확인 중..." : "그룹 참여하기"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default FamilyJoinPage;

--- a/src/pages/FamilyJoinPage.tsx
+++ b/src/pages/FamilyJoinPage.tsx
@@ -5,57 +5,93 @@ const FamilyJoinPage: React.FC = () => {
   const navigate = useNavigate();
   const [inviteCode, setInviteCode] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isChecking, setIsChecking] = useState(false);
+  const isReady = inviteCode.trim().length > 0;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!inviteCode.trim()) return;
+    await handleConfirm();
+  };
+
+  const handleConfirm = async () => {
+    if (!isReady) return;
     setIsSubmitting(true);
     try {
       // TODO: API 연동 (초대 코드 검증 및 참여)
-      // await api.joinFamily({ inviteCode })
-      navigate("/home");
+      // const { leaderName } = await api.joinFamily({ inviteCode })
+      setIsChecking(true);
+      // 대기 화면을 잠시 보여준 뒤 홈으로 이동 (임시)
+      setTimeout(() => {
+        navigate("/home");
+      }, 5000);
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  if (isChecking) {
+    return (
+      <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+        <div className="w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-24">
+          <div className="mt-36">
+            <div className="text-2xl font-extrabold leading-snug">
+              <span className="text-[#018941]">그룹 리더</span> 님이
+              <br />
+              참가를 확인 중이에요
+            </div>
+            <p className="text-gray-400 mt-4">조금만 기다려주세요!</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
-      <div className="w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-20 pb-10">
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="text-sm text-gray-500 mb-6 hover:text-gray-700"
-        >
-          ← 뒤로가기
-        </button>
-
-        <h1 className="text-2xl font-bold mb-6">가족 참여하기</h1>
-
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div>
-            <label className="block text-sm text-gray-600 mb-2">
-              초대 코드
-            </label>
-            <input
-              type="text"
-              value={inviteCode}
-              onChange={(e) => setInviteCode(e.target.value)}
-              placeholder="예: ABCD-1234"
-              className="w-full rounded-lg border border-gray-200 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#018941] uppercase tracking-wider"
-              maxLength={32}
-              required
-            />
+      <div className="relative w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-20 pb-28">
+        {/* 인사 및 안내 문구 */}
+        <div className="mt-32 mb-8">
+          <div className="text-[#018941] font-extrabold text-xl mb-2">
+            안녕하세요!
           </div>
+          <h1 className="text-3xl font-extrabold leading-snug text-[#2c2c2c] mb-6">
+            그룹에 참여 하시는군요!
+          </h1>
+          <div className="text-2xl text-gray-500 mb-2">
+            초대코드를 입력해 주세요
+          </div>
+          <div className="text-gray-400">
+            가족 구성원이 공유한 초대코드를 입력하면 참여할 수 있어요
+          </div>
+        </div>
 
-          <button
-            type="submit"
-            disabled={isSubmitting || !inviteCode.trim()}
-            className="w-full bg-[#018941] disabled:opacity-60 text-white py-4 rounded-lg font-medium text-lg hover:bg-[#016b31] transition-colors"
-          >
-            {isSubmitting ? "확인 중..." : "그룹 참여하기"}
-          </button>
+        {/* 입력 폼 */}
+        <form onSubmit={handleSubmit}>
+          <input
+            type="text"
+            value={inviteCode}
+            onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
+            placeholder="ABCDEF"
+            className="w-full rounded-2xl border border-gray-200 px-5 py-4 text-lg focus:outline-none focus:ring-2 focus:ring-[#018941] uppercase tracking-widest"
+            maxLength={32}
+            required
+          />
+          <button type="submit" className="hidden" />
         </form>
+
+        {/* 하단 확인 버튼 (입력 시 노출) */}
+        {isReady && (
+          <div className="absolute left-0 right-0 bottom-6 px-6 pb-[env(safe-area-inset-bottom)]">
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={isSubmitting}
+              className="w-full bg-[#018941] text-white py-4 rounded-xl font-medium text-lg shadow-md hover:bg-[#016b31] transition-colors"
+            >
+              {isSubmitting ? "확인 중..." : "확인"}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/FamilySetupPage.tsx
+++ b/src/pages/FamilySetupPage.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+const FamilySetupPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+      <div className="w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-20 pb-10">
+        {/* 헤더 텍스트 */}
+        <div className="mt-32 mb-6">
+          <h1 className="text-3xl font-extrabold leading-snug text-[#2c2c2c]">
+            곧 가족들과
+            <br />
+            만날 준비가 돼요
+          </h1>
+        </div>
+        <p className="text-gray-500 mb-6 leading-relaxed">
+          새로운 가족 그룹을 만들거나
+          <br />
+          기존 가족 그룹에 참여할 수 있어요
+        </p>
+
+        {/* 카드: 가족 만들기 */}
+        <button
+          type="button"
+          onClick={() => navigate("/family/create")}
+          className="w-full text-left bg-white rounded-2xl shadow-sm border border-gray-100 px-5 py-5 mb-5 hover:shadow-md transition-shadow"
+        >
+          <div className="flex items-center">
+            <div className="w-16 h-16 mr-4 rounded-xl bg-[#018941]/10 flex items-center justify-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="w-8 h-8 text-[#018941]"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 4v16m8-8H4"
+                />
+              </svg>
+            </div>
+            <div className="flex-1">
+              <div className="text-lg font-semibold text-[#1f2937]">
+                가족 만들기
+              </div>
+              <div className="text-gray-500 text-sm mt-1">
+                새로운 가족 그룹을 생성하고
+                <br />
+                가족 구성원을 초대해보세요
+              </div>
+            </div>
+          </div>
+        </button>
+
+        {/* 카드: 가족 참여하기 */}
+        <button
+          type="button"
+          onClick={() => navigate("/family/join")}
+          className="w-full text-left bg-white rounded-2xl shadow-sm border border-gray-100 px-5 py-5 hover:shadow-md transition-shadow"
+        >
+          <div className="flex items-center">
+            <div className="w-16 h-16 mr-4 rounded-xl bg-gray-100 flex items-center justify-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="w-8 h-8 text-gray-500"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M12 14a5 5 0 100-10 5 5 0 000 10z"
+                />
+              </svg>
+            </div>
+            <div className="flex-1">
+              <div className="text-lg font-semibold text-[#1f2937]">
+                가족 참여하기
+              </div>
+              <div className="text-gray-500 text-sm mt-1">
+                초대받은 가족 그룹에
+                <br />
+                참여해보세요
+              </div>
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FamilySetupPage;

--- a/src/pages/FamilySubscribePage.tsx
+++ b/src/pages/FamilySubscribePage.tsx
@@ -12,8 +12,7 @@ const FamilySubscribePage: React.FC = () => {
   const familyName = state.familyName || "우리 가족";
 
   const handlePay = async () => {
-    // TODO: 결제 연동 (PG사 선택 후 구현)
-    navigate("/home");
+    navigate("/payment", { state: { familyName } });
   };
 
   return (

--- a/src/pages/FamilySubscribePage.tsx
+++ b/src/pages/FamilySubscribePage.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+interface LocationState {
+  familyName?: string;
+}
+
+const FamilySubscribePage: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = (location.state || {}) as LocationState;
+  const familyName = state.familyName || "우리 가족";
+
+  const handlePay = async () => {
+    // TODO: 결제 연동 (PG사 선택 후 구현)
+    navigate("/home");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+      <div className="relative w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-20 pb-28">
+        <div className="mt-32">
+          <h1 className="text-3xl font-extrabold leading-snug text-[#2c2c2c] mb-6">
+            가족의 이야기를 이어가기 위해
+            <br />
+            구독을 완료해주세요
+          </h1>
+          <p className="text-gray-500">현재 선택된 그룹: {familyName}</p>
+        </div>
+
+        <div className="absolute left-0 right-0 bottom-6 px-6 pb-[env(safe-area-inset-bottom)]">
+          <button
+            type="button"
+            onClick={handlePay}
+            className="w-full bg-[#018941] text-white py-4 rounded-xl font-medium text-lg shadow-md hover:bg-[#016b31] transition-colors"
+          >
+            결제하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FamilySubscribePage;

--- a/src/pages/GettingStartedPage.tsx
+++ b/src/pages/GettingStartedPage.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+const GettingStartedPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+      <div className="relative w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-24 pb-28">
+        <div className="mt-40">
+          <div className="text-2xl font-extrabold leading-snug text-[#2c2c2c]">
+            이제 <span className="text-[#018941]">가족</span>과의
+            <br />
+            소중한 추억을 기록해보세요
+          </div>
+        </div>
+
+        <div className="absolute left-0 right-0 bottom-6 px-6 pb-[env(safe-area-inset-bottom)]">
+          <button
+            type="button"
+            onClick={() => navigate("/home")}
+            className="w-full bg-[#018941] text-white py-4 rounded-xl font-medium text-lg shadow-md hover:bg-[#016b31] transition-colors"
+          >
+            시작하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GettingStartedPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -9,6 +9,7 @@ import {
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const [isProcessing, setIsProcessing] = React.useState(false);
 
   useEffect(() => {
     // 카카오 SDK 초기화
@@ -19,24 +20,31 @@ const LoginPage: React.FC = () => {
       const urlParams = new URLSearchParams(location.search);
       const code = urlParams.get("code");
 
-      if (code) {
+      if (code && !isProcessing) {
+        setIsProcessing(true);
         console.log("인가 코드 발견:", code);
         try {
           const user = await handleKakaoRedirect();
           if (user) {
             console.log("모바일 로그인 성공:", user);
+            // URL에서 인가 코드 제거 후 튜토리얼로 이동
+            window.history.replaceState({}, document.title, "/login");
             navigate("/tutorial");
           } else {
             // 임시 해결책: 인가 코드가 있으면 로그인 성공으로 간주
             console.log(
               "인가 코드 확인됨 - 로그인 성공으로 간주하고 튜토리얼로 이동"
             );
+            // URL에서 인가 코드 제거 후 튜토리얼로 이동
+            window.history.replaceState({}, document.title, "/login");
             navigate("/tutorial");
           }
         } catch (error) {
           console.error("모바일 로그인 오류:", error);
           // 오류가 발생해도 인가 코드가 있으면 성공으로 간주
           console.log("오류 발생했지만 인가 코드가 있으므로 튜토리얼로 이동");
+          // URL에서 인가 코드 제거 후 튜토리얼로 이동
+          window.history.replaceState({}, document.title, "/login");
           navigate("/tutorial");
         }
       }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,9 +1,65 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import {
+  loginWithKakao,
+  initKakao,
+  handleKakaoRedirect,
+} from "../services/kakaoAuth";
 
 const LoginPage: React.FC = () => {
-  const handleKakaoLogin = () => {
-    // TODO: 카카오 로그인 구현
-    console.log("카카오 로그인");
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    // 카카오 SDK 초기화
+    initKakao();
+
+    // 모바일에서 리다이렉트 후 인가 코드 처리
+    const handleRedirect = async () => {
+      const urlParams = new URLSearchParams(location.search);
+      const code = urlParams.get("code");
+
+      if (code) {
+        console.log("인가 코드 발견:", code);
+        try {
+          const user = await handleKakaoRedirect();
+          if (user) {
+            console.log("모바일 로그인 성공:", user);
+            navigate("/tutorial");
+          } else {
+            // 임시 해결책: 인가 코드가 있으면 로그인 성공으로 간주
+            console.log(
+              "인가 코드 확인됨 - 로그인 성공으로 간주하고 튜토리얼로 이동"
+            );
+            navigate("/tutorial");
+          }
+        } catch (error) {
+          console.error("모바일 로그인 오류:", error);
+          // 오류가 발생해도 인가 코드가 있으면 성공으로 간주
+          console.log("오류 발생했지만 인가 코드가 있으므로 튜토리얼로 이동");
+          navigate("/tutorial");
+        }
+      }
+    };
+
+    handleRedirect();
+  }, [location.search, navigate]);
+
+  const handleKakaoLogin = async () => {
+    try {
+      const user = await loginWithKakao();
+      if (user) {
+        console.log("로그인 성공:", user);
+        // 로그인 성공 시 튜토리얼 페이지로 이동
+        navigate("/tutorial");
+      } else {
+        console.error("로그인 실패");
+        alert("카카오 로그인에 실패했습니다. 다시 시도해주세요.");
+      }
+    } catch (error) {
+      console.error("로그인 오류:", error);
+      alert("로그인 중 오류가 발생했습니다.");
+    }
   };
 
   return (

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -1,0 +1,178 @@
+import React, { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+interface LocationState {
+  familyName?: string;
+}
+
+const PaymentPage: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = (location.state || {}) as LocationState;
+  const familyName = state.familyName || "우리 가족";
+
+  const [method, setMethod] = useState<"kakaopay" | "card">("kakaopay");
+  const [agreeAll, setAgreeAll] = useState(false);
+  const [agreePolicy, setAgreePolicy] = useState(false);
+
+  const handlePay = () => {
+    if (!agreePolicy) return;
+    // TODO: 실제 결제 연동
+    navigate("/home");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+      <div className="relative w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-16 pb-28">
+        <h1 className="text-[22px] font-extrabold text-[#2c2c2c] mb-6">
+          결제정보 입력
+        </h1>
+
+        <section className="mb-8">
+          <h2 className="text-xl font-bold text-[#2c2c2c] mb-3">구독 정보</h2>
+          <div className="rounded-2xl border border-gray-200 shadow-sm bg-white">
+            <div className="px-4 py-4 flex items-center border-b border-gray-100">
+              <div className="w-28 text-gray-500 text-sm">구독 상품</div>
+              <div className="flex-1">
+                <div className="text-[#018941] font-semibold">
+                  부모님께 이어드림 선물하기
+                </div>
+                <div className="text-xs text-gray-400 mt-1">
+                  그룹명: {familyName}
+                </div>
+              </div>
+              <button className="text-xs text-[#018941] border border-[#018941] rounded-md px-2 py-1">
+                구독주기 변경
+              </button>
+            </div>
+            <div className="px-4 py-4 flex items-center border-b border-gray-100">
+              <div className="w-28 text-gray-500 text-sm">구독 기간</div>
+              <div className="flex-1 text-[#2c2c2c] text-sm">
+                2025.08.09 ~ 2025.09.09
+              </div>
+            </div>
+            <div className="px-4 py-4 flex items-center">
+              <div className="w-28 text-gray-500 text-sm">다음 결제일</div>
+              <div className="flex-1 text-[#2c2c2c] text-sm">2025.09.09</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-xl font-bold text-[#2c2c2c] mb-3">결제금액</h2>
+          <div className="rounded-2xl border border-gray-200 shadow-sm bg-white">
+            <div className="px-4 py-4 flex items-center border-b border-gray-100">
+              <div className="w-28 text-gray-500 text-sm">상품 가격</div>
+              <div className="flex-1 text-right text-[#2c2c2c]">11,900원</div>
+            </div>
+            <div className="px-4 py-4 flex items-center border-b border-gray-100">
+              <div className="w-28 text-gray-500 text-sm">할인 금액</div>
+              <div className="flex-1 text-right">
+                <span className="text-[#e11d48] mr-2">25%</span>8,900원
+              </div>
+            </div>
+            <div className="px-4 py-4 flex items-center">
+              <div className="w-28 text-gray-500 text-sm">다음 결제일</div>
+              <div className="flex-1 text-right text-[#2c2c2c]">2025.09.09</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-xl font-bold text-[#2c2c2c] mb-3">결제수단</h2>
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              onClick={() => setMethod("kakaopay")}
+              className={`rounded-2xl border px-4 py-5 text-left shadow-sm transition-colors ${method === "kakaopay" ? "border-[#018941] ring-1 ring-[#018941]" : "border-gray-200"}`}
+            >
+              <div className="flex items-center">
+                <span className="inline-flex items-center justify-center w-8 h-5 text-[11px] font-bold rounded bg-[#fee500] text-black mr-2">
+                  pay
+                </span>
+                <span className="font-medium">카카오페이</span>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setMethod("card")}
+              className={`rounded-2xl border px-4 py-5 text-left shadow-sm transition-colors ${method === "card" ? "border-[#018941] ring-1 ring-[#018941]" : "border-gray-200"}`}
+            >
+              <div className="flex items-center">
+                <span className="font-medium">신용카드</span>
+              </div>
+            </button>
+          </div>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-xl font-bold text-[#2c2c2c] mb-3">약관 동의</h2>
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm">
+            <label className="flex items-center px-4 py-4 border-b border-gray-100 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={agreeAll}
+                onChange={(e) => {
+                  setAgreeAll(e.target.checked);
+                  setAgreePolicy(e.target.checked);
+                }}
+                className="mr-3 accent-[#018941] w-5 h-5"
+              />
+              <span className="font-semibold">전체 동의하기</span>
+            </label>
+            <label className="flex items-start px-4 py-4 gap-3">
+              <input
+                type="checkbox"
+                checked={agreePolicy}
+                onChange={(e) => {
+                  setAgreePolicy(e.target.checked);
+                  if (!e.target.checked) setAgreeAll(false);
+                }}
+                className="mt-0.5 accent-[#018941] w-5 h-5"
+              />
+              <div className="flex-1 text-sm text-gray-600">
+                [필수] 자동결제 상품 인지 및 취소, 환불, 소득 공제 정책 등 상품
+                구매 정책 동의
+              </div>
+              <button className="text-sm text-gray-400">보기</button>
+            </label>
+          </div>
+        </section>
+
+        <section className="mb-28">
+          <h2 className="text-xl font-bold text-[#2c2c2c] mb-3">유의사항</h2>
+          <ul className="text-xs text-gray-500 space-y-2 list-disc pl-5 leading-relaxed">
+            <li>
+              구독결제는 구독기간 마지막 날 결제되며, 결제 후 구독기간은 자동
+              갱신됩니다.
+            </li>
+            <li>
+              구독결제 중단을 원할 경우, 구독기간 종료 하루 전까지 구독을
+              해지해야 합니다.
+            </li>
+            <li>
+              만 19세 미만의 회원의 유료서비스 이용은 법정대리인의 동의가
+              필요합니다.
+            </li>
+            <li>
+              법정대리인이 동의하지 않은 경우 이용계약을 취소할 수 있습니다.
+            </li>
+          </ul>
+        </section>
+
+        <div className="absolute left-0 right-0 bottom-6 px-6 pb-[env(safe-area-inset-bottom)]">
+          <button
+            type="button"
+            onClick={handlePay}
+            disabled={!agreePolicy}
+            className="w-full bg-[#018941] disabled:opacity-40 text-white py-4 rounded-xl font-medium text-lg shadow-md hover:bg-[#016b31] transition-colors"
+          >
+            결제하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentPage;

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -17,8 +17,8 @@ const PaymentPage: React.FC = () => {
 
   const handlePay = () => {
     if (!agreePolicy) return;
-    // TODO: 실제 결제 연동
-    navigate("/home");
+    // 결제 버튼 클릭 시 기본정보 입력 플로우로 이동
+    navigate("/recipient", { state: { familyName } });
   };
 
   return (

--- a/src/pages/RecipientInfoPage.tsx
+++ b/src/pages/RecipientInfoPage.tsx
@@ -1,0 +1,179 @@
+import React, { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+type Step = 1 | 2 | 3 | 4 | 5;
+
+const onlyDigits = (value: string) => value.replace(/\D/g, "");
+
+const formatBirth = (digits: string) => {
+  const v = onlyDigits(digits).slice(0, 8);
+  if (v.length <= 4) return v;
+  if (v.length <= 6) return `${v.slice(0, 4)} ${v.slice(4, 6)}`;
+  return `${v.slice(0, 4)} ${v.slice(4, 6)} ${v.slice(6, 8)}`;
+};
+
+const formatPhone = (digits: string) => {
+  const v = onlyDigits(digits).slice(0, 11);
+  if (v.length < 4) return v;
+  if (v.length < 8) return `${v.slice(0, 3)} ${v.slice(3)}`;
+  return `${v.slice(0, 3)} ${v.slice(3, 7)} ${v.slice(7)}`;
+};
+
+const RecipientInfoPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>(1);
+  const [name, setName] = useState("");
+  const [birth, setBirth] = useState("");
+  const [phone, setPhone] = useState("");
+  const [address, setAddress] = useState("");
+
+  const birthDigits = useMemo(() => onlyDigits(birth), [birth]);
+  const phoneDigits = useMemo(() => onlyDigits(phone), [phone]);
+
+  const canNext = useMemo(() => {
+    switch (step) {
+      case 1:
+        return name.trim().length > 0;
+      case 2:
+        return birthDigits.length === 8;
+      case 3:
+        return phoneDigits.length >= 10 && phoneDigits.length <= 11;
+      case 4:
+        return address.trim().length > 5;
+      default:
+        return true;
+    }
+  }, [step, name, birthDigits, phoneDigits, address]);
+
+  const handleNext = () => {
+    if (!canNext) return;
+    if (step < 4) {
+      setStep((s) => (s + 1) as Step);
+    } else {
+      setStep(5);
+    }
+  };
+
+  const handleFinish = () => {
+    // TODO: 입력 정보 저장/전송
+    navigate("/getting-started");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+      <div className="relative w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white min-h-screen px-6 pt-20 pb-28">
+        {step <= 4 ? (
+          <>
+            {/* 타이틀 */}
+            <div className="mt-28 mb-8">
+              <div className="text-[#018941] font-extrabold text-xl mb-2">
+                책자를 받으실 분은
+              </div>
+              <h1 className="text-3xl font-extrabold leading-snug text-[#2c2c2c] mb-6">
+                어떤 분이신가요?
+              </h1>
+
+              {/* 이전 단계 값 미리보기 */}
+              <div className="text-[#2c2c2c] space-y-2">
+                {name && <div>{name}</div>}
+                {birthDigits.length > 0 && <div>{formatBirth(birth)}</div>}
+                {phoneDigits.length > 0 && <div>{formatPhone(phone)}</div>}
+              </div>
+
+              {/* 안내문 */}
+              <p className="text-gray-400 mt-2">
+                {step === 1 && "이름을 입력해주세요"}
+                {step === 2 && "생년월일 8자리를 입력해주세요"}
+                {step === 3 && "전화번호를 입력해주세요"}
+                {step === 4 && "주소를 입력해주세요"}
+              </p>
+            </div>
+
+            {/* 입력 영역 */}
+            <div className="mt-6">
+              {step === 1 && (
+                <input
+                  autoFocus
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="홍길동"
+                  className="w-full rounded-2xl border border-gray-200 px-5 py-4 text-lg focus:outline-none focus:ring-2 focus:ring-[#018941]"
+                  maxLength={30}
+                />
+              )}
+              {step === 2 && (
+                <input
+                  autoFocus
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={birth}
+                  onChange={(e) => setBirth(onlyDigits(e.target.value))}
+                  placeholder="20000101"
+                  className="w-full rounded-2xl border border-gray-200 px-5 py-4 text-lg focus:outline-none focus:ring-2 focus:ring-[#018941] tracking-widest"
+                  maxLength={8}
+                />
+              )}
+              {step === 3 && (
+                <input
+                  autoFocus
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={phone}
+                  onChange={(e) => setPhone(onlyDigits(e.target.value))}
+                  placeholder="01012345678"
+                  className="w-full rounded-2xl border border-gray-200 px-5 py-4 text-lg focus:outline-none focus:ring-2 focus:ring-[#018941] tracking-widest"
+                  maxLength={11}
+                />
+              )}
+              {step === 4 && (
+                <textarea
+                  autoFocus
+                  value={address}
+                  onChange={(e) => setAddress(e.target.value)}
+                  placeholder="서울특별시 중구 세종대로 110"
+                  className="w-full rounded-2xl border border-gray-200 px-5 py-4 text-lg h-28 resize-none focus:outline-none focus:ring-2 focus:ring-[#018941]"
+                />
+              )}
+            </div>
+
+            {/* 하단 버튼 */}
+            <div className="absolute left-0 right-0 bottom-6 px-6 pb-[env(safe-area-inset-bottom)]">
+              <button
+                type="button"
+                onClick={handleNext}
+                disabled={!canNext}
+                className="w-full bg-[#018941] disabled:opacity-40 text-white py-4 rounded-xl font-medium text-lg shadow-md hover:bg-[#016b31] transition-colors"
+              >
+                확인
+              </button>
+            </div>
+          </>
+        ) : (
+          <div className="mt-36">
+            <div className="text-2xl font-extrabold leading-snug">
+              <span className="text-[#018941]">{name}</span> 님께
+              <br />
+              매월 책자를 보내드려요
+            </div>
+            <p className="text-gray-400 mt-4 text-sm">
+              정보는 주문 완료 전까지 언제든 수정하실 수 있어요
+            </p>
+
+            <div className="absolute left-0 right-0 bottom-6 px-6 pb-[env(safe-area-inset-bottom)]">
+              <button
+                type="button"
+                onClick={handleFinish}
+                className="w-full bg-[#018941] text-white py-4 rounded-xl font-medium text-lg shadow-md hover:bg-[#016b31] transition-colors"
+              >
+                확인
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RecipientInfoPage;

--- a/src/pages/TutorialPage.tsx
+++ b/src/pages/TutorialPage.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+interface TutorialStep {
+  id: number;
+  title: string;
+  icon: React.ReactNode;
+  description?: string;
+}
+
+const TutorialPage: React.FC = () => {
+  const [currentStep, setCurrentStep] = useState(1);
+  const navigate = useNavigate();
+
+  const tutorialSteps: TutorialStep[] = [
+    {
+      id: 1,
+      title: "언제 어디서나 소식 공유",
+      icon: (
+        <svg
+          className="w-16 h-16"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+          />
+        </svg>
+      ),
+    },
+    {
+      id: 2,
+      title: "가족들은 디지털 아카이빙",
+      icon: (
+        <svg
+          className="w-16 h-16"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+          />
+        </svg>
+      ),
+    },
+    {
+      id: 3,
+      title: "부모님께 배송되는 한 권의 따뜻한 소식책자",
+      icon: (
+        <svg
+          className="w-16 h-16"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+          />
+        </svg>
+      ),
+    },
+  ];
+
+  const handleNext = () => {
+    if (currentStep < 3) {
+      setCurrentStep(currentStep + 1);
+    } else {
+      // 튜토리얼 완료 시 홈페이지로 이동
+      navigate("/home");
+    }
+  };
+
+  const handleSkip = () => {
+    // 건너뛰기 시 홈페이지로 이동
+    navigate("/home");
+  };
+
+  const currentStepData = tutorialSteps.find((step) => step.id === currentStep);
+
+  const renderTitle = () => {
+    const baseClass = "text-2xl font-bold text-center leading-relaxed mb-8";
+    if (currentStep === 1) {
+      return (
+        <h1 className={baseClass}>
+          <span className="text-black">언제 어디서나</span>
+          <span className="text-[#018941]">소식 공유</span>
+        </h1>
+      );
+    }
+    if (currentStep === 2) {
+      return (
+        <h1 className={baseClass}>
+          <span className="text-black">가족들은 </span>
+          <span className="text-[#018941]">디지털 아카이빙</span>
+        </h1>
+      );
+    }
+    return (
+      <h1 className={baseClass}>
+        <span className="text-black">부모님께 배송되는</span>
+        <br />
+        <span className="text-black">한 권의 </span>
+        <span className="text-[#018941]">따뜻한 소식책자</span>
+      </h1>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f2f2f7] flex justify-center">
+      <div className="w-full max-w-full sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl bg-white relative min-h-screen flex flex-col">
+        {/* 건너뛰기 버튼 */}
+        <div className="flex justify-end p-6">
+          <button
+            onClick={handleSkip}
+            className="text-[#018941] text-sm font-medium hover:text-[#016b31] transition-colors"
+          >
+            건너뛰기
+          </button>
+        </div>
+
+        {/* 메인 콘텐츠: 중앙 정렬 */}
+        <div className="flex-1 flex flex-col items-center justify-center px-6">
+          {renderTitle()}
+
+          {/* 아이콘 */}
+          <div className="w-24 h-24 bg-[#018941]/10 rounded-2xl flex items-center justify-center">
+            <div className="text-[#018941]">{currentStepData?.icon}</div>
+          </div>
+        </div>
+
+        {/* 하단 고정 영역 */}
+        <div className="px-6 pb-8">
+          {/* 진행 상태 표시 */}
+          <div className="flex items-center justify-center gap-3 mb-8">
+            {tutorialSteps.map((step) => (
+              <div
+                key={step.id}
+                aria-hidden
+                className={`transition-all duration-300 ease-out ${
+                  step.id === currentStep
+                    ? "w-12 h-3 bg-[#018941] rounded-full"
+                    : "w-2.5 h-2.5 rounded-full bg-gray-300"
+                }`}
+              />
+            ))}
+          </div>
+
+          {/* 다음/확인 버튼 */}
+          <button
+            onClick={handleNext}
+            className="w-full bg-[#018941] text-white py-4 px-6 rounded-lg font-medium text-lg hover:bg-[#016b31] transition-colors"
+          >
+            {currentStep === 3 ? "확인" : "다음"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TutorialPage;

--- a/src/pages/TutorialPage.tsx
+++ b/src/pages/TutorialPage.tsx
@@ -76,8 +76,8 @@ const TutorialPage: React.FC = () => {
     if (currentStep < 3) {
       setCurrentStep(currentStep + 1);
     } else {
-      // 튜토리얼 완료 시 홈페이지로 이동
-      navigate("/home");
+      // 튜토리얼 완료 시 가족 설정 페이지로 이동
+      navigate("/family-setup");
     }
   };
 

--- a/src/services/kakaoAuth.ts
+++ b/src/services/kakaoAuth.ts
@@ -1,0 +1,208 @@
+import type { KakaoUser, KakaoLoginResponse } from "../types/auth";
+
+// 카카오 JavaScript 키 (환경 변수에서 가져오기)
+const KAKAO_JS_KEY = import.meta.env.VITE_KAKAO_JS_KEY;
+
+// 카카오 초기화
+export const initKakao = (): void => {
+  if (typeof window !== "undefined" && window.Kakao) {
+    if (!window.Kakao.isInitialized()) {
+      console.log("카카오 JavaScript 키:", KAKAO_JS_KEY);
+      window.Kakao.init(KAKAO_JS_KEY);
+      console.log("카카오 SDK 초기화 완료");
+    }
+  }
+};
+
+// 모바일 기기 감지
+const isMobile = (): boolean => {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
+};
+
+// 카카오 로그인 실행
+export const loginWithKakao = async (): Promise<KakaoUser | null> => {
+  try {
+    if (typeof window === "undefined" || !window.Kakao) {
+      throw new Error("카카오 SDK가 로드되지 않았습니다.");
+    }
+
+    // 모바일 환경에서는 리다이렉트 방식 사용
+    if (isMobile()) {
+      console.log("모바일 환경 감지 - 리다이렉트 방식으로 로그인");
+      const redirectUri = `${window.location.origin}/login`;
+      const authUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_JS_KEY}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code`;
+      window.location.href = authUrl;
+      return null; // 리다이렉트되므로 null 반환
+    }
+
+    // 데스크톱 환경에서는 팝업 방식 사용
+    return new Promise((resolve, reject) => {
+      console.log("데스크톱 환경 - 팝업 방식으로 로그인");
+
+      // 카카오 로그인 실행 (웹 전용 방식)
+      window.Kakao.Auth.login({
+        // scope 제거 - 기본 권한만으로 로그인
+        success: async (authObj: KakaoLoginResponse) => {
+          try {
+            console.log("카카오 로그인 성공:", authObj);
+            console.log("액세스 토큰:", authObj.access_token);
+            console.log("토큰 타입:", authObj.token_type);
+
+            // 토큰을 로컬 스토리지에 저장
+            localStorage.setItem("kakao_access_token", authObj.access_token);
+            localStorage.setItem("kakao_refresh_token", authObj.refresh_token);
+            console.log("토큰 저장 완료");
+
+            // 즉시 사용자 정보 가져오기 시도
+            try {
+              console.log("사용자 정보 가져오기 시작...");
+              const userInfo = await getKakaoUserInfo();
+              if (userInfo) {
+                console.log("사용자 정보 가져오기 성공:", userInfo);
+                resolve(userInfo);
+              } else {
+                console.error("사용자 정보가 null입니다.");
+                reject(new Error("사용자 정보를 가져올 수 없습니다."));
+              }
+            } catch (userError) {
+              console.error("사용자 정보 가져오기 실패:", userError);
+              reject(userError);
+            }
+          } catch (error) {
+            console.error("로그인 성공 후 처리 중 오류:", error);
+            reject(error);
+          }
+        },
+        fail: (err: unknown) => {
+          console.error("카카오 로그인 실패:", err);
+          reject(new Error("카카오 로그인에 실패했습니다."));
+        },
+      });
+    });
+  } catch (error) {
+    console.error("카카오 로그인 오류:", error);
+    return null;
+  }
+};
+
+// 카카오 사용자 정보 가져오기
+export const getKakaoUserInfo = async (): Promise<KakaoUser | null> => {
+  try {
+    if (typeof window === "undefined" || !window.Kakao) {
+      throw new Error("카카오 SDK가 로드되지 않았습니다.");
+    }
+
+    // 토큰 유효성 확인
+    const accessToken = window.Kakao.Auth.getAccessToken();
+    if (!accessToken) {
+      throw new Error("액세스 토큰이 없습니다.");
+    }
+
+    console.log("사용자 정보 요청 - 액세스 토큰:", accessToken);
+    console.log("카카오 SDK 초기화 상태:", window.Kakao.isInitialized());
+
+    const response = await window.Kakao.API.request({
+      url: "/v2/user/me",
+    });
+
+    console.log("사용자 정보 응답:", response);
+    return response as KakaoUser;
+  } catch (error) {
+    console.error("사용자 정보 가져오기 오류:", error);
+
+    // 401 오류인 경우 토큰 제거
+    if (
+      error &&
+      typeof error === "object" &&
+      "status" in error &&
+      error.status === 401
+    ) {
+      console.log("토큰이 만료되었습니다. 로그아웃 처리합니다.");
+      logoutFromKakao();
+    }
+
+    return null;
+  }
+};
+
+// 카카오 로그아웃
+export const logoutFromKakao = (): void => {
+  try {
+    if (typeof window !== "undefined" && window.Kakao) {
+      window.Kakao.Auth.logout();
+      // 로컬 스토리지에서 토큰 제거
+      localStorage.removeItem("kakao_access_token");
+      localStorage.removeItem("kakao_refresh_token");
+      console.log("카카오 로그아웃 완료");
+    }
+  } catch (error) {
+    console.error("카카오 로그아웃 오류:", error);
+  }
+};
+
+// 모바일 웹에서 리다이렉트 후 인가 코드 처리
+export const handleKakaoRedirect = async (): Promise<KakaoUser | null> => {
+  try {
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get("code");
+
+    if (code) {
+      console.log("인가 코드 발견:", code);
+
+      // 인가 코드로 토큰 교환 (올바른 방법)
+      return new Promise((resolve, reject) => {
+        window.Kakao.Auth.login({
+          success: async (authObj: any) => {
+            try {
+              console.log("토큰 교환 성공:", authObj);
+
+              // 토큰을 로컬 스토리지에 저장
+              localStorage.setItem("kakao_access_token", authObj.access_token);
+              localStorage.setItem(
+                "kakao_refresh_token",
+                authObj.refresh_token
+              );
+
+              // 사용자 정보 가져오기
+              const userInfo = await getKakaoUserInfo();
+              resolve(userInfo);
+            } catch (error) {
+              console.error("사용자 정보 가져오기 실패:", error);
+              reject(error);
+            }
+          },
+          fail: (err: any) => {
+            console.error("토큰 교환 실패:", err);
+            reject(err);
+          },
+        });
+      });
+    }
+
+    return null;
+  } catch (error) {
+    console.error("리다이렉트 처리 오류:", error);
+    return null;
+  }
+};
+
+// 로그인 상태 확인
+export const checkKakaoLoginStatus = (): boolean => {
+  if (typeof window === "undefined" || !window.Kakao) {
+    return false;
+  }
+
+  const token = localStorage.getItem("kakao_access_token");
+  return !!token && window.Kakao.Auth.getAccessToken() !== null;
+};
+
+// 액세스 토큰 가져오기
+export const getKakaoAccessToken = (): string | null => {
+  if (typeof window === "undefined" || !window.Kakao) {
+    return null;
+  }
+
+  return window.Kakao.Auth.getAccessToken();
+};

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,38 @@
+// 카카오 사용자 정보 타입
+export interface KakaoUser {
+  id: number;
+  connected_at: string;
+  properties: {
+    nickname: string;
+    profile_image?: string;
+    thumbnail_image?: string;
+  };
+  kakao_account: {
+    profile: {
+      nickname: string;
+      profile_image_url?: string;
+      thumbnail_image_url?: string;
+    };
+    email?: string;
+    age_range?: string;
+    birthday?: string;
+    gender?: string;
+  };
+}
+
+// 카카오 로그인 응답 타입
+export interface KakaoLoginResponse {
+  access_token: string;
+  token_type: string;
+  refresh_token: string;
+  expires_in: number;
+  scope?: string;
+  refresh_token_expires_in: number;
+}
+
+// 로그인 상태 타입
+export interface LoginState {
+  isLoggedIn: boolean;
+  user: KakaoUser | null;
+  accessToken: string | null;
+}

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,0 +1,24 @@
+// 카카오 SDK 전역 타입 정의
+declare global {
+  interface Window {
+    Kakao: {
+      init: (key: string) => void;
+      isInitialized: () => boolean;
+      Auth: {
+        login: (options: {
+          scope?: string;
+          success: (authObj: any) => void;
+          fail: (err: any) => void;
+        }) => void;
+        authorize: (options: { redirectUri: string }) => void;
+        logout: () => void;
+        getAccessToken: () => string | null;
+      };
+      API: {
+        request: (options: { url: string }) => Promise<any>;
+      };
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
## 🚀 Background
- 이 PR에서 다루는 내용과 간단한 요약
feat: 온보딩(튜토리얼) · 가족 생성/참여 · 결제 · 기본정보 입력 플로우 추가 + 카카오 로그인(임시)
## 🥥 Changes
## 남은 작업 / 이슈
카카오 로그인
토큰 교환 백엔드 연동 필요(현재 실패 상태) [kakao-login-fix]
웹 전용/리다이렉트 모드 정리 및 팝업 차단 대응 [web-only-login]
결제
실제 PG 연동(카카오페이/카드) 및 금액/주기/쿠폰 로직
가족 생성/참여
API 연동(그룹 생성, 초대코드 검증, 리더명 표기)
“리더 확인 중” 실시간/폴링 처리
복사문구/폰트/여백 최종 디자인 핏 조정


## - 주요 코드 변경 사항 및 작업 내역
### 라우팅 추가
/tutorial: 튜토리얼 3단계
/family-setup: 가족 설정 허브
/family/create: 가족 만들기
/family/join: 가족 참여하기
/family/subscribe: 결제 안내
/payment: 결제하기 UI
/recipient: 수령자(책 받을 분) 기본정보 입력 4단계 + 완료
/getting-started: 완료 안내 화면(“이제 가족과의 소중한 추억을…”)
### 화면/컴포넌트
TutorialPage: 레이아웃/진행 점 스타일 정돈
FamilySetupPage: 만들기/참여 선택 카드
FamilyCreatePage: 이름 입력 → 확인 버튼 하단 고정
FamilyJoinPage: 초대코드 입력 → 확인 → “리더 확인 중” 대기 화면
FamilySubscribePage: 결제 안내 → 결제하기 버튼
PaymentPage: 결제정보 입력(상품/금액/수단/약관) → 결제하기 버튼
RecipientInfoPage: 이름/생년월일/전화번호/주소 단계 입력 → 완료
GettingStartedPage: 시작하기 버튼 → 홈 이동

카카오 로그인(임시)
SDK 초기화 및 로그인 트리거 연결
토큰 교환 실패 시 상태 노출
## 🧪 Testing
- [ ] 수행한 테스트 목록과 방법

## 📸 Screenshots
- 필요시 UI 변경사항 스크린샷 첨부

## ⚓ Related Issue
- closes #(이슈번호)
