### PR TITLE
[Feat/#12] 기본 플로우 4차 구현 - API 연동 및 보관함 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "eardream-fe",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^7.8.1"
+        "react-router-dom": "^7.8.1",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1752,7 +1754,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2146,6 +2148,12 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2182,6 +2190,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2246,6 +2265,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2326,6 +2358,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2368,7 +2412,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2396,6 +2440,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2404,6 +2457,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2425,6 +2492,51 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2795,6 +2907,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2824,6 +2972,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2832,6 +2989,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2860,6 +3054,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2882,6 +3088,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -3344,6 +3589,15 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3366,6 +3620,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3618,6 +3893,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4246,6 +4527,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,17 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 4000",
+    "dev": "vite --port 3000",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.8.1"
+    "react-router-dom": "^7.8.1",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,11 @@ import SubscribePage from "./pages/SubscribePage";
 import AutoPaymentPage from "./pages/AutoPaymentPage";
 import NewsDetailPage from "./pages/NewsDetailPage";
 import PaymentManagePage from "./pages/PaymentManagePage";
+import AlbumCreatePage from "./pages/AlbumCreatePage";
+import AlbumEditPage from "./pages/AlbumEditPage";
+import AlbumInfoPage from "./pages/AlbumInfoPage";
+import AlbumPhotoPickerPage from "./pages/AlbumPhotoPickerPage";
+import EditNewsPage from "./pages/EditNewsPage";
 
 function App() {
   useEffect(() => {
@@ -46,7 +51,7 @@ function App() {
           <Route path="/" element={<SplashPage />} />
           <Route path="/splash" element={<SplashPage />} />
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/home" element={<HomePage />} />
+
           <Route path="/write-news" element={<WriteNewsPage />} />
           <Route path="/news-box" element={<NewsBoxPage />} />
           <Route path="/news-preview/:id" element={<NewsPreviewPage />} />
@@ -66,11 +71,20 @@ function App() {
           <Route path="/getting-started" element={<GettingStartedPage />} />
           <Route path="/mypage/subscribe" element={<SubscribePage />} />
           <Route path="/mypage/auto-payment" element={<AutoPaymentPage />} />
-          <Route path="/home/news/detail" element={<NewsDetailPage />} />
           <Route
-            path="/mypage/auto-payment/manage"
+            path="/home/news/detail/:postId"
+            element={<NewsDetailPage />}
+          />
+          <Route path="/home/news/edit/:postId" element={<EditNewsPage />} />
+          <Route
+            path="/mypage/auto-payment/manage/:id"
             element={<PaymentManagePage />}
           />
+          <Route path="/home/album/create" element={<AlbumCreatePage />} />
+          <Route path="/home/album/edit" element={<AlbumEditPage />} />
+          <Route path="/home/album/info" element={<AlbumInfoPage />} />
+          <Route path="/home/album/pick" element={<AlbumPhotoPickerPage />} />
+          <Route path="/home" element={<HomePage />} />
           <Route
             path="/home"
             element={

--- a/src/assets/icons/OpenBoxIcon.tsx
+++ b/src/assets/icons/OpenBoxIcon.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const OpenBoxIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    className="w-10 h-10 text-[#018941]"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 64 64"
+    {...props}
+  >
+    <path d="M8 20L32 8l24 12-24 12-24-12z" className="stroke-current" />
+    <path d="M8 20v24l24 12 24-12V20" className="stroke-current" />
+    <line x1="32" y1="32" x2="32" y2="56" className="stroke-current" />
+  </svg>
+);
+
+export default OpenBoxIcon;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -15,12 +15,6 @@ const Header: React.FC<HeaderProps> = ({
 }) => {
   return (
     <header className="bg-white/80 backdrop-blur-xl border-b border-gray-100 px-4 py-3 flex items-center justify-between sticky top-0 z-10">
-      <div className="p-5">
-        <h1 className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-lg font-semibold text-gray-900">
-          {title}
-        </h1>
-      </div>
-
       <div className="flex items-center">
         {showBackButton && (
           <button
@@ -42,6 +36,12 @@ const Header: React.FC<HeaderProps> = ({
             </svg>
           </button>
         )}
+      </div>
+
+      <div className="p-5">
+        <h1 className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-lg font-semibold text-gray-900">
+          {title}
+        </h1>
       </div>
 
       {rightElement && (

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -43,7 +43,7 @@ const Header: React.FC<HeaderProps> = ({
           </button>
         )}
       </div>
-      <h1 className="text-lg font-semibold text-gray-900">{title}</h1>
+
       {rightElement && (
         <div className="flex items-center absolute right-4">{rightElement}</div>
       )}

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -51,7 +51,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onCommentSend }) => {
       <h3 className="font-medium text-gray-900 mb-3">{post.title}</h3>
 
       {/* 게시물 이미지 */}
-      <div className="bg-gray-200 rounded-lg h-48 mb-3 flex items-center justify-center overflow-hidden">
+      <div className="bg-gray-200 rounded-lg h-70 mb-3 flex items-center justify-center overflow-hidden">
         {post.imageUrls ? (
           <img
             src={post.imageUrls[0]}

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -51,7 +51,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onCommentSend }) => {
       <h3 className="font-medium text-gray-900 mb-3">{post.title}</h3>
 
       {/* 게시물 이미지 */}
-      <div className="bg-gray-200 rounded-lg h-70 mb-3 flex items-center justify-center overflow-hidden">
+      <div className="bg-gray-200 rounded-lg w-full h-full mb-3 flex items-center justify-center overflow-hidden">
         {post.imageUrls ? (
           <img
             src={post.imageUrls[0]}
@@ -70,7 +70,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onCommentSend }) => {
       </div>
 
       {/* 게시물 내용 */}
-      <p className="text-gray-700 text-sm mb-4 whitespace-pre-line">
+      <p className="text-gray-700 text-me mb-4 whitespace-pre-line">
         {post.content}
       </p>
 

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -12,12 +12,12 @@ const PostCard: React.FC<PostCardProps> = ({ post, onCommentSend }) => {
   const navigate = useNavigate();
   const handleCommentSend = (message: string) => {
     if (onCommentSend) {
-      onCommentSend(post.id, message);
+      onCommentSend(post.id.toString(), message);
     }
   };
 
   const handleCardClick = () => {
-    navigate("/home/news/detail");
+    navigate(`/home/news/detail/${post.id}`);
   };
 
   return (
@@ -28,11 +28,13 @@ const PostCard: React.FC<PostCardProps> = ({ post, onCommentSend }) => {
       {/* 게시물 헤더 */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center space-x-3">
-          <img
-            src={post.authorImage}
-            alt={post.author}
-            className="w-10 h-10 rounded-full bg-gray-200"
-          />
+          {post.authorImage && post.authorImage.trim() !== "" && (
+            <img
+              src={post.authorImage}
+              alt={post.author}
+              className="w-10 h-10 rounded-full bg-gray-200"
+            />
+          )}
           <div className="flex items-center">
             <p className="font-medium text-gray-900">{post.author}</p>
             <p className="text-sm text-gray-500 ml-3">{post.timeAgo}</p>
@@ -49,14 +51,22 @@ const PostCard: React.FC<PostCardProps> = ({ post, onCommentSend }) => {
       <h3 className="font-medium text-gray-900 mb-3">{post.title}</h3>
 
       {/* 게시물 이미지 */}
-      <div className="bg-gray-200 rounded-lg h-48 mb-3 flex items-center justify-center">
-        <svg
-          className="w-12 h-12 text-gray-400"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z" />
-        </svg>
+      <div className="bg-gray-200 rounded-lg h-48 mb-3 flex items-center justify-center overflow-hidden">
+        {post.imageUrls ? (
+          <img
+            src={post.imageUrls[0]}
+            alt={post.title}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <svg
+            className="w-12 h-12 text-gray-400"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z" />
+          </svg>
+        )}
       </div>
 
       {/* 게시물 내용 */}

--- a/src/components/feed/PostDetail.tsx
+++ b/src/components/feed/PostDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import type { Post } from "../../types/feed";
 import CommentInput from "./CommentInput";
 import Comment from "./Comment";
@@ -6,39 +7,55 @@ import type { CommentType } from "../../types/feed";
 import Button from "../common/Button";
 import Alert from "../common/Alert";
 import WarningIcon from "../../assets/icons/WarningIcon";
+import PostImageSlider from "./PostImageSlider";
 
 const comments: CommentType[] = [
   {
-    author: "홍길동",
-    authorImage: "",
-    content: "역시 우리 가족이야",
-    createdAt: "2025-08-21 12:30",
+    author: "엄마",
+    authorImage: "/images/family/mom.png",
+    content: "오늘 사진 너무 예쁘다! 👍",
+    createdAt: "2025-08-24 12:30",
   },
   {
-    author: "김철수",
-    authorImage: "",
-    content: "오랜만에 보니 좋네요",
-    createdAt: "2025-08-21 13:15",
+    author: "아빠",
+    authorImage: "/images/family/dad.png",
+    content: "잘했다, 우리 가족 최고.",
+    createdAt: "2025-08-24 13:15",
   },
   {
-    author: "이영희",
-    authorImage: "",
-    content: "댓글",
-    createdAt: "2025-08-21 10:10",
+    author: "형",
+    authorImage: "/images/family/brother.png",
+    content: "ㅋㅋ 나도 같이 가고 싶었는데…",
+    createdAt: "2025-08-24 14:05",
+  },
+  {
+    author: "동생",
+    authorImage: "/images/family/sister.png",
+    content: "나 다음에 꼭 사진 찍자!",
+    createdAt: "2025-08-24 14:30",
+  },
+  {
+    author: "할머니",
+    authorImage: "/images/family/grandma.png",
+    content: "사진 보니 마음이 따뜻해지네...",
+    createdAt: "2025-08-24 15:00",
   },
 ];
 
 interface PostCardProps {
   post: Post;
   isManager?: boolean;
-  onCommentSend?: (postId: string, message: string) => void;
+  onCommentSend?: (postId: number, message: string) => void;
+  onDeletePost?: (postId: number) => void;
 }
 
 const PostDetail: React.FC<PostCardProps> = ({
   post,
   isManager = false,
   onCommentSend,
+  onDeletePost,
 }) => {
+  const navigate = useNavigate();
   const [isShowDeleteAlert, setIsShowDeleteAlert] = useState<boolean>(false);
 
   const handleCommentSend = (message: string) => {
@@ -47,9 +64,13 @@ const PostDetail: React.FC<PostCardProps> = ({
     }
   };
 
-  /* TODO: 게시글 삭제 함수 추가*/
-  const handlePostDelete = () => {
-    setIsShowDeleteAlert(true);
+  const handleDelete = () => {
+    setIsShowDeleteAlert(false);
+    onDeletePost?.(post.id);
+  };
+
+  const handleEdit = () => {
+    navigate(`/home/news/edit/${post.id}`, { state: { post } });
   };
 
   return (
@@ -59,24 +80,36 @@ const PostDetail: React.FC<PostCardProps> = ({
         <p className="text-lg font-medium text-gray-900 mb-3">{post.title}</p>
 
         {isManager && (
-          <Button
-            variant="dangerOutline"
-            size="small"
-            onClick={handlePostDelete}
-          >
-            삭제
-          </Button>
+          <div className="flex justify-between gap-2">
+            <Button
+              variant="secondaryOutline"
+              size="small"
+              onClick={handleEdit}
+            >
+              편집
+            </Button>
+
+            <Button
+              variant="dangerOutline"
+              size="small"
+              onClick={() => setIsShowDeleteAlert(true)}
+            >
+              삭제
+            </Button>
+          </div>
         )}
       </div>
 
       {/* 게시물 헤더 */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center justify-between mb-2">
         <div className="flex items-center space-x-3">
-          <img
-            src={post.authorImage}
-            alt={post.author}
-            className="w-10 h-10 rounded-full bg-gray-200"
-          />
+          {post.authorImage && (
+            <img
+              src={post.authorImage}
+              alt={post.author}
+              className="w-10 h-10 rounded-full bg-gray-200"
+            />
+          )}
           <div className="flex items-center">
             <p className="font-medium text-gray-900">{post.author}</p>
             <p className="text-sm text-gray-500 ml-3">{post.timeAgo}</p>
@@ -85,13 +118,14 @@ const PostDetail: React.FC<PostCardProps> = ({
       </div>
 
       {/* 상호작용 */}
-      <div className="flex items-center space-x-4 text-sm text-gray-500 mb-4">
+      <div className="flex items-center space-x-4 text-sm text-gray-500">
         <div className="flex items-center space-x-1">
           <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
           </svg>
           <span>{post.likes}</span>
         </div>
+
         <div className="flex items-center space-x-1">
           <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
             <path d="M21.99 4c0-1.1-.89-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4-.01-18zM18 14H6v-2h12v2zm0-3H6V9h12v2zm0-3H6V6h12v2z" />
@@ -101,18 +135,12 @@ const PostDetail: React.FC<PostCardProps> = ({
       </div>
 
       {/* 게시물 이미지 */}
-      <div className="bg-gray-200 rounded-lg h-48 mb-3 flex items-center justify-center">
-        <svg
-          className="w-12 h-12 text-gray-400"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z" />
-        </svg>
+      <div className="mt-6">
+        <PostImageSlider imageUrls={post.imageUrls || []} title={post.title} />
       </div>
 
       {/* 게시물 내용 */}
-      <p className="text-gray-700 text-sm mb-4 whitespace-pre-line">
+      <p className="text-gray-700 text-sm mt-8 mb-8 whitespace-pre-line">
         {post.content}
       </p>
 
@@ -120,7 +148,7 @@ const PostDetail: React.FC<PostCardProps> = ({
 
       <div className="flex flex-col items-start">
         {/* 댓글 개수 */}
-        <p className="text-gray-700 text-me font-semibold mb-4 whitespace-pre-line">
+        <p className="text-gray-700 text-me font-semibold mt-4 mb-6 whitespace-pre-line">
           댓글 {post.comments}개
         </p>
 
@@ -135,13 +163,14 @@ const PostDetail: React.FC<PostCardProps> = ({
         <CommentInput onSend={handleCommentSend} />
       </div>
 
+      {/* 게시글 삭제 (작성자만 가능) */}
       {isShowDeleteAlert && (
         <Alert
           icon={<WarningIcon className="w-10 h-10 text-red-600" />}
           message="정말 삭제하시겠어요?"
           confirmText="삭제하기"
           confirmVariant="danger"
-          onConfirm={handlePostDelete}
+          onConfirm={handleDelete}
           confirmClassName="flex-1 ml-4"
           cancelText="취소"
           cancelVariant="secondaryOutline"

--- a/src/components/feed/PostImageSlider.tsx
+++ b/src/components/feed/PostImageSlider.tsx
@@ -19,7 +19,7 @@ const PostImageSlider: React.FC<PostImageSliderProps> = ({
     setCurrentIndex((prev) => (prev === imageUrls.length - 1 ? 0 : prev + 1));
 
   return (
-    <div className="relative w-full h-48 mb-3">
+    <div className="relative w-full h-full mb-3">
       <img
         src={imageUrls[currentIndex]}
         alt={`${title} ${currentIndex + 1}`}

--- a/src/components/feed/PostImageSlider.tsx
+++ b/src/components/feed/PostImageSlider.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+
+interface PostImageSliderProps {
+  imageUrls: string[];
+  title: string;
+}
+
+const PostImageSlider: React.FC<PostImageSliderProps> = ({
+  imageUrls,
+  title,
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  if (!imageUrls.length) return <div>이미지 없음</div>;
+
+  const prevImage = () =>
+    setCurrentIndex((prev) => (prev === 0 ? imageUrls.length - 1 : prev - 1));
+  const nextImage = () =>
+    setCurrentIndex((prev) => (prev === imageUrls.length - 1 ? 0 : prev + 1));
+
+  return (
+    <div className="relative w-full h-48 mb-3">
+      <img
+        src={imageUrls[currentIndex]}
+        alt={`${title} ${currentIndex + 1}`}
+        className="w-full h-full object-cover rounded-lg"
+      />
+
+      {imageUrls.length > 1 && (
+        <>
+          <button
+            onClick={prevImage}
+            className="absolute left-2 top-1/2 transform -translate-y-1/2 bg-gray-100 bg-opacity-30 text-white p-2 rounded-full"
+          >
+            ◀
+          </button>
+          <button
+            onClick={nextImage}
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-gray-100 bg-opacity-30 text-white p-2 rounded-full"
+          >
+            ▶
+          </button>
+          <div className="absolute bottom-2 right-2 bg-gray-200 bg-opacity-20 text-black text-xs px-2 py-1 rounded">
+            {currentIndex + 1} / {imageUrls.length}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PostImageSlider;

--- a/src/components/other/Album.tsx
+++ b/src/components/other/Album.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import ImageIcon from "../../assets/icons/ImageIcon";
+
+interface AlbumProps {
+  images?: string[];
+  coverImage?: string;
+  albumName: string;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  className?: string;
+}
+
+const Album: React.FC<AlbumProps> = ({
+  images,
+  coverImage,
+  albumName,
+  onDelete,
+  className,
+}) => {
+  const navigate = useNavigate();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const handleOptionClick = (option: string) => {
+    console.log("클릭 옵션:", option);
+    setDropdownOpen(false);
+    switch (option) {
+      case "앨범 정보":
+        navigate("/home/album/info");
+        break;
+      case "앨범 편집":
+        navigate("/home/album/edit");
+        break;
+      case "삭제":
+        onDelete?.();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div
+      className={`relative bg-white rounded-lg shadow-sm overflow-hidden ${className}`}
+      style={{ aspectRatio: "1 / 1" }}
+    >
+      {coverImage ? (
+        <img
+          src={coverImage}
+          alt="앨범 커버"
+          className="w-full h-full object-cover"
+        />
+      ) : images && images.length > 0 ? (
+        <div className="grid grid-cols-2 grid-rows-2 w-full h-full gap-1">
+          {images.slice(0, 4).map((src, idx) => (
+            <img
+              key={idx}
+              src={src}
+              alt={`앨범 이미지 ${idx + 1}`}
+              className="w-full h-full object-cover"
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="w-full h-full bg-gray-100 flex items-center justify-center">
+          <ImageIcon className="w-10 h-10 text-gray-300" />
+        </div>
+      )}
+
+      <div className="absolute bottom-2 right-2 bg-white bg-opacity-50 text-black text-sm px-2 py-1 shadow-sm rounded">
+        {albumName}
+      </div>
+
+      <div className="absolute top-2 right-2">
+        <div>
+          <button
+            className="p-1 rounded hover:bg-gray-100"
+            onClick={() => setDropdownOpen((prev) => !prev)}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 text-gray-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <circle cx="12" cy="5" r="1.5" />
+              <circle cx="12" cy="12" r="1.5" />
+              <circle cx="12" cy="19" r="1.5" />
+            </svg>
+          </button>
+        </div>
+
+        {dropdownOpen && (
+          <div className="absolute right-0 mt-2 w-36 bg-white border rounded shadow-lg z-10">
+            <ul>
+              {["앨범 정보", "앨범 편집", "삭제"].map((option) => (
+                <li
+                  key={option}
+                  className={`px-4 py-2 cursor-pointer ${
+                    option === "삭제"
+                      ? "text-red-500 hover:bg-red-100"
+                      : "hover:bg-gray-100"
+                  }`}
+                  onClick={() => handleOptionClick(option)}
+                >
+                  {option}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Album;

--- a/src/components/other/PaymentCard.tsx
+++ b/src/components/other/PaymentCard.tsx
@@ -1,29 +1,38 @@
 import React from "react";
 import Button from "../common/Button";
 import { useNavigate } from "react-router-dom";
+import { usePaymentStore } from "../../stores/usePaymentStore";
 
 interface PaymentCardProps {
+  id: number;
   icon: React.ReactNode;
   label: string;
   cardNumber?: string;
-  isBasic: boolean;
+  onClick?: () => void;
 }
 
 const PaymentCard: React.FC<PaymentCardProps> = ({
+  id,
   icon,
   label,
   cardNumber,
-  isBasic = false,
+  onClick,
 }) => {
   const navigate = useNavigate();
+  const payments = usePaymentStore((state) => state.payments);
 
-  /* TODO: 결제수단 관리 페이지로 이동 필요 */
+  const payment = payments.find((p) => p.id === id);
+  if (!payment) return null;
+
   const handleEditPayment = () => {
-    navigate("/mypage/auto-payment/manage");
+    navigate(`/mypage/auto-payment/manage/${id}`);
   };
 
   return (
-    <div className="bg-white rounded-lg p-4 shadow-sm mt-4">
+    <div
+      className="bg-white rounded-lg p-4 shadow-sm mt-4 cursor-pointer"
+      onClick={onClick}
+    >
       <div className="flex items-center space-x-4 mb-4">
         {icon}
 
@@ -33,7 +42,7 @@ const PaymentCard: React.FC<PaymentCardProps> = ({
         </div>
 
         <div className="flex gap-4">
-          {isBasic && (
+          {payment.isBasic && (
             <div className="bg-[#018941] text-white shadow-sm font-medium rounded-2xl transition-all px-5 py-2.5 text-base">
               <p>기본</p>
             </div>

--- a/src/components/other/PaymentCard.tsx
+++ b/src/components/other/PaymentCard.tsx
@@ -1,31 +1,23 @@
 import React from "react";
 import Button from "../common/Button";
 import { useNavigate } from "react-router-dom";
-import { usePaymentStore } from "../../stores/usePaymentStore";
-
+import type { Payment } from "../../stores/usePaymentStore";
+// PaymentCard.tsx
 interface PaymentCardProps {
-  id: number;
+  payment: Payment;
   icon: React.ReactNode;
-  label: string;
-  cardNumber?: string;
   onClick?: () => void;
 }
 
 const PaymentCard: React.FC<PaymentCardProps> = ({
-  id,
+  payment,
   icon,
-  label,
-  cardNumber,
   onClick,
 }) => {
   const navigate = useNavigate();
-  const payments = usePaymentStore((state) => state.payments);
-
-  const payment = payments.find((p) => p.id === id);
-  if (!payment) return null;
 
   const handleEditPayment = () => {
-    navigate(`/mypage/auto-payment/manage/${id}`);
+    navigate(`/mypage/auto-payment/manage/${payment.id}`);
   };
 
   return (
@@ -37,17 +29,20 @@ const PaymentCard: React.FC<PaymentCardProps> = ({
         {icon}
 
         <div className="flex-1">
-          <h2 className="text-sm font-semibold text-gray-600">{cardNumber}</h2>
-          <h2 className="text-sm font-semibold text-gray-400">{label}</h2>
+          <h2 className="text-sm font-semibold text-gray-600">
+            {payment.cardNumber}
+          </h2>
+          <h2 className="text-sm font-semibold text-gray-400">
+            {payment.label}
+          </h2>
         </div>
 
         <div className="flex gap-4">
           {payment.isBasic && (
             <div className="bg-[#018941] text-white shadow-sm font-medium rounded-2xl transition-all px-5 py-2.5 text-base">
-              <p>기본</p>
+              기본
             </div>
           )}
-
           <Button variant="outline" size="small" onClick={handleEditPayment}>
             편집
           </Button>

--- a/src/pages/AlbumCreatePage.tsx
+++ b/src/pages/AlbumCreatePage.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import Header from "../components/common/Header";
+import MainLayout from "../components/layout/MainLayout";
+import Button from "../components/common/Button";
+import Input from "../components/common/Input";
+import ImageUploadButton from "../components/common/ImageUploadButton";
+
+const album = {
+  name: "김가족의 앨범",
+  postCount: "3",
+  author: "김가족",
+  writeDate: "2025년 08월 19일",
+};
+
+const AlbumCreatePage: React.FC = () => {
+  const navigate = useNavigate();
+  const [profileImage, setProfileImage] = useState<string>("");
+
+  const handleSave = () => {
+    navigate("/home");
+  };
+
+  const handleImageChange = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      if (event.target?.result) {
+        setProfileImage(event.target.result as string);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <MainLayout>
+      <Header title="내 정보 관리" />
+
+      <div className="flex justify-center mt-8">
+        <ImageUploadButton
+          image={profileImage}
+          onChange={handleImageChange}
+          size={100}
+          isShowPreview={true}
+        />
+      </div>
+
+      {/* 이름 수정 */}
+      <div className="p-4 flex flex-col space-y-10">
+        <div>
+          <p className="font-bold">앨범 이름</p>
+          <Input
+            value={album.name}
+            placeholder="앨범 이름을 입력해주세요"
+            onChange={setProfileImage}
+            className="mt-4"
+          />
+        </div>
+
+        <Button
+          type="button"
+          variant="primary"
+          size="medium"
+          onClick={handleSave}
+          className="mt-30 w-full"
+        >
+          추가하기
+        </Button>
+      </div>
+    </MainLayout>
+  );
+};
+
+export default AlbumCreatePage;

--- a/src/pages/AlbumEditPage.tsx
+++ b/src/pages/AlbumEditPage.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import MainLayout from "../components/layout/MainLayout";
+import Button from "../components/common/Button";
+import Header from "../components/common/Header";
+
+const dummyPhotos = Array.from({ length: 20 }).map((_, idx) => ({
+  id: String(idx),
+  uri: "",
+  selected: false,
+}));
+
+const AlbumEditPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [photos, setPhotos] = useState(dummyPhotos);
+
+  const toggleSelect = (idx: number) => {
+    const newPhotos = [...photos];
+    newPhotos[idx].selected = !newPhotos[idx].selected;
+    setPhotos(newPhotos);
+  };
+
+  const handleConfirm = () => {
+    navigate("/home/album/create");
+  };
+
+  const handleAddAlbum = () => {
+    console.log("앨범 추가 버튼 클릭");
+  };
+
+  return (
+    <MainLayout>
+      <Header title="앨범 편집" />
+
+      <div className="grid grid-cols-2 gap-2 p-4">
+        {/* + 앨범 추가하기 버튼 */}
+        <div
+          className="flex items-center justify-center cursor-pointer bg-gray-100 rounded-lg w-full h-24"
+          onClick={handleAddAlbum}
+        >
+          <span className="text-2xl font-bold text-gray-400">+</span>
+        </div>
+
+        {/* 기존 사진들 */}
+        {photos.map((photo, idx) => (
+          <div
+            key={photo.id}
+            className="relative cursor-pointer"
+            onClick={() => toggleSelect(idx)}
+          >
+            <img
+              src={photo.uri}
+              alt={`photo-${idx}`}
+              className={`p-4 w-full h-24 object-cover rounded-lg transition-all duration-200 ${
+                photo.selected ? "opacity-60" : "opacity-100"
+              }`}
+            />
+
+            <div
+              className={`absolute top-2 right-2 w-5 h-5 rounded-full flex items-center justify-center text-white text-xs font-bold
+                ${photo.selected ? "bg-[#018941]" : "bg-gray-100"}`}
+            >
+              {photo.selected ? "✓" : ""}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Button
+        variant="primary"
+        size="medium"
+        className="mt-6 w-full"
+        onClick={handleConfirm}
+        disabled={photos.filter((p) => p.selected).length === 0}
+      >
+        확인
+      </Button>
+    </MainLayout>
+  );
+};
+
+export default AlbumEditPage;

--- a/src/pages/AlbumInfoPage.tsx
+++ b/src/pages/AlbumInfoPage.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import Header from "../components/common/Header";
+import MainLayout from "../components/layout/MainLayout";
+import Button from "../components/common/Button";
+import Input from "../components/common/Input";
+import ImageUploadButton from "../components/common/ImageUploadButton";
+
+const AlbumInfoPage: React.FC = () => {
+  const album = {
+    name: "김가족의 앨범",
+    postCount: "3",
+    author: "김가족",
+    writeDate: "2025년 08월 19일",
+  };
+
+  const navigate = useNavigate();
+  const [profileImage, setProfileImage] = useState<string>("");
+  const [albumName, setAlbumName] = useState<string>(album.name);
+
+  /* TODO: 앨범 정보 저장하는 함수 로직 */
+  const handleSave = () => {
+    navigate("/home");
+  };
+
+  const handleImageChange = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      if (event.target?.result) {
+        setProfileImage(event.target.result as string);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <MainLayout>
+      <Header title="앨범 정보" />
+
+      <div className="flex justify-center mt-8">
+        <ImageUploadButton
+          image={profileImage}
+          onChange={handleImageChange}
+          size={100}
+          isShowPreview={true}
+        />
+      </div>
+
+      {/* 앨범 정보 수정 */}
+      <div className="space-y-6 p-4">
+        <div>
+          <p className="font-bold">앨범 이름</p>
+          <Input
+            value={albumName}
+            placeholder="앨범 이름을 입력해주세요"
+            onChange={setAlbumName}
+            className="mt-2"
+          />
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <p className="font-bold">게시글 갯수</p>
+            <p className="text-gray-400 mt-2">{album.postCount}개</p>
+          </div>
+
+          <div>
+            <p className="font-bold">작성자</p>
+            <p className="text-gray-400 mt-2">{album.author}</p>
+          </div>
+
+          <div>
+            <p className="font-bold">작성 날짜</p>
+            <p className="text-gray-400 mt-2">{album.writeDate}</p>
+          </div>
+        </div>
+
+        <Button
+          type="button"
+          variant="primary"
+          size="medium"
+          onClick={handleSave}
+          className="mt-30 w-full"
+        >
+          추가하기
+        </Button>
+      </div>
+    </MainLayout>
+  );
+};
+
+export default AlbumInfoPage;

--- a/src/pages/AlbumPhotoPickerPage.tsx
+++ b/src/pages/AlbumPhotoPickerPage.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import MainLayout from "../components/layout/MainLayout";
+import Button from "../components/common/Button";
+import Header from "../components/common/Header";
+
+const dummyPhotos = Array.from({ length: 20 }).map((_, idx) => ({
+  id: String(idx),
+  uri: "",
+  selected: false,
+}));
+
+const AlbumPhotoPickerPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [photos, setPhotos] = useState(dummyPhotos);
+
+  const toggleSelect = (idx: number) => {
+    const newPhotos = [...photos];
+    newPhotos[idx].selected = !newPhotos[idx].selected;
+    setPhotos(newPhotos);
+  };
+
+  const handleConfirm = () => {
+    navigate("/home/album/create");
+  };
+
+  return (
+    <MainLayout>
+      <Header title="앨범 추가하기" />
+
+      {/* 사진 그리드 */}
+      <div className="grid grid-cols-2 gap-2 p-4">
+        {photos.map((photo, idx) => (
+          <div
+            key={photo.id}
+            className="relative cursor-pointer"
+            onClick={() => toggleSelect(idx)}
+          >
+            <img
+              src={photo.uri}
+              alt={`photo-${idx}`}
+              className={`p-4 w-full h-24 object-cover rounded-lg transition-all duration-200 ${
+                photo.selected ? "opacity-60" : "opacity-100"
+              }`}
+            />
+
+            <div
+              className={`absolute top-2 right-2 w-5 h-5 rounded-full flex items-center justify-center text-white text-xs font-bold
+    ${photo.selected ? "bg-[#018941]" : "bg-gray-100"}`}
+            >
+              {photo.selected ? "✓" : ""}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 선택 완료 버튼 */}
+      <Button
+        variant="primary"
+        size="medium"
+        className="mt-6 w-full"
+        onClick={handleConfirm}
+        disabled={photos.filter((p) => p.selected).length === 0}
+      >
+        확인
+      </Button>
+    </MainLayout>
+  );
+};
+
+export default AlbumPhotoPickerPage;

--- a/src/pages/AutoPaymentPage.tsx
+++ b/src/pages/AutoPaymentPage.tsx
@@ -7,55 +7,33 @@ import Alert from "../components/common/Alert";
 import WarningIcon from "../assets/icons/WarningIcon";
 import CardIcon from "../assets/icons/CardIcon";
 import PaymentCard from "../components/other/PaymentCard";
+import { usePaymentStore } from "../stores/usePaymentStore";
+import type { Payment } from "../stores/usePaymentStore";
 
 const AutoPaymentPage: React.FC = () => {
-  const [isShowAlert, setIsShowAlert] = useState<boolean>(false);
+  const [isShowAlert, setIsShowAlert] = useState(false);
+  const payments = usePaymentStore((state) => state.payments);
+  const [selectedPayment, setSelectedPayment] = useState<Payment>(payments[0]);
+
+  const handleShowAlert = () => setIsShowAlert((prev) => !prev);
+
+  /* TODO: 자동 결제 해지 함수 */
+  const handleCancelAutoPayment = () => {};
+
+  /* 카드 선택 시 selectedPayment 변경 */
+  const handleSelectPayment = (id: number) => {
+    const payment = payments.find((p) => p.id === id);
+    if (payment) setSelectedPayment(payment);
+  };
 
   // TODO: 실제 사용자 데이터로 교체
   const user = {
     name: "김가족",
     email: "family@example.com",
-    profileImage: "/api/placeholder/80/80",
-    subscriptionPlan: "월 구독",
     subscriptionStatus: "정상 구독 중",
     nextPaymentDate: "2024년 2월 4일",
     subscriptionStartDate: "2023년 1월 1일",
-    price: "8,900원",
-    delivery: "배송 완료",
-    basicPayment: "신한카드",
-    basicPaymentInfo: "4343 4342 2222 3444",
   };
-
-  const payments = [
-    {
-      id: 1,
-      label: "신한카드",
-      cardNumber: "**** - **** - **** - 1234",
-      isBasic: true,
-      icon: <CardIcon className="w-10 h-10 text-[#018941]" />,
-    },
-    {
-      id: 2,
-      label: "국민카드",
-      cardNumber: "**** - **** - **** - 5678",
-      isBasic: false,
-      icon: <CardIcon className="w-10 h-10 text-[#016b33]" />,
-    },
-    {
-      id: 3,
-      label: "카카오뱅크 카드",
-      cardNumber: "**** - **** - **** - 9012",
-      isBasic: false,
-      icon: <CardIcon className="w-10 h-10 text-[#feca1b]" />,
-    },
-  ];
-
-  const handleShowAlert = () => {
-    setIsShowAlert((pre) => !pre);
-  };
-
-  /* TODO: 자동 결제 해지 함수 추가 */
-  const handleCancelAutoPayment = () => {};
 
   return (
     <MainLayout>
@@ -74,7 +52,6 @@ const AutoPaymentPage: React.FC = () => {
           ]}
         />
 
-        {/* 자동 결제 해지 버튼 */}
         <Button
           type="button"
           size="medium"
@@ -103,11 +80,17 @@ const AutoPaymentPage: React.FC = () => {
         <p className="text-xl font-bold mt-8">결제 수단 관리</p>
         {payments.map((payment) => (
           <PaymentCard
-            key={payment.cardNumber}
-            icon={payment.icon}
+            key={payment.id}
+            id={payment.id}
+            icon={
+              <CardIcon
+                className="w-10 h-10"
+                style={{ color: payment.iconColor }}
+              />
+            }
             label={payment.label}
             cardNumber={payment.cardNumber}
-            isBasic={payment.isBasic}
+            onClick={() => handleSelectPayment(payment.id)}
           />
         ))}
 
@@ -125,10 +108,3 @@ const AutoPaymentPage: React.FC = () => {
 };
 
 export default AutoPaymentPage;
-
-// <div className="flex items-center">
-//               <span className="inline-flex items-center justify-center w-8 h-5 text-[11px] font-bold rounded bg-[#fee500] text-black mr-2">
-//                 pay
-//               </span>
-//               <span className="font-medium">카카오페이</span>
-//             </div>

--- a/src/pages/AutoPaymentPage.tsx
+++ b/src/pages/AutoPaymentPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Header from "../components/common/Header";
 import MainLayout from "../components/layout/MainLayout";
 import Button from "../components/common/Button";
@@ -8,23 +8,15 @@ import WarningIcon from "../assets/icons/WarningIcon";
 import CardIcon from "../assets/icons/CardIcon";
 import PaymentCard from "../components/other/PaymentCard";
 import { usePaymentStore } from "../stores/usePaymentStore";
-import type { Payment } from "../stores/usePaymentStore";
 
 const AutoPaymentPage: React.FC = () => {
   const [isShowAlert, setIsShowAlert] = useState(false);
   const payments = usePaymentStore((state) => state.payments);
-  const [selectedPayment, setSelectedPayment] = useState<Payment>(payments[0]);
 
   const handleShowAlert = () => setIsShowAlert((prev) => !prev);
 
   /* TODO: 자동 결제 해지 함수 */
   const handleCancelAutoPayment = () => {};
-
-  /* 카드 선택 시 selectedPayment 변경 */
-  const handleSelectPayment = (id: number) => {
-    const payment = payments.find((p) => p.id === id);
-    if (payment) setSelectedPayment(payment);
-  };
 
   // TODO: 실제 사용자 데이터로 교체
   const user = {
@@ -34,6 +26,8 @@ const AutoPaymentPage: React.FC = () => {
     nextPaymentDate: "2024년 2월 4일",
     subscriptionStartDate: "2023년 1월 1일",
   };
+
+  useEffect(() => {}, []);
 
   return (
     <MainLayout>
@@ -81,16 +75,13 @@ const AutoPaymentPage: React.FC = () => {
         {payments.map((payment) => (
           <PaymentCard
             key={payment.id}
-            id={payment.id}
+            payment={payment}
             icon={
               <CardIcon
                 className="w-10 h-10"
                 style={{ color: payment.iconColor }}
               />
             }
-            label={payment.label}
-            cardNumber={payment.cardNumber}
-            onClick={() => handleSelectPayment(payment.id)}
           />
         ))}
 

--- a/src/pages/EditNewsPage.tsx
+++ b/src/pages/EditNewsPage.tsx
@@ -27,8 +27,6 @@ const EditNewsPage: React.FC = () => {
   const [additionalImages, setAdditionalImages] = useState<ImageFile[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const userId = useUserStore((state) => state.userId);
-
   const MAX_IMAGES = 4;
   const MIN_DESCRIPTION = 0;
   const MAX_DESCRIPTION = 100;

--- a/src/pages/EditNewsPage.tsx
+++ b/src/pages/EditNewsPage.tsx
@@ -1,32 +1,49 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import Header from "../components/common/Header";
 import MainLayout from "../components/layout/MainLayout";
-import { writePost } from "../services/postsApi";
+import { patchPosts } from "../services/postsApi";
 import { useUserStore } from "../stores/useUserStore";
+import type { Post } from "../types/feed";
 
 interface ImageFile {
   id: string;
-  file: File;
+  file?: File;
   preview: string;
-  description: string;
+  isFromServer?: boolean;
 }
 
-const WriteNewsPage: React.FC = () => {
+const EditNewsPage: React.FC = () => {
   const navigate = useNavigate();
-  const [title, setTitle] = useState("");
+  const location = useLocation();
+  const post = location.state?.post as Post;
+
+  const [title, setTitle] = useState(post?.title || "");
+  const [description, setDescription] = useState(post?.content || "");
+
   const [mainImage, setMainImage] = useState<File | null>(null);
   const [mainImagePreview, setMainImagePreview] = useState<string>("");
+
   const [additionalImages, setAdditionalImages] = useState<ImageFile[]>([]);
-  const [description, setDescription] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const familyId = useUserStore((state) => state.familyId);
   const userId = useUserStore((state) => state.userId);
 
   const MAX_IMAGES = 4;
   const MIN_DESCRIPTION = 0;
   const MAX_DESCRIPTION = 100;
+
+  useEffect(() => {
+    if (post.imageUrls && post.imageUrls.length > 0) {
+      setMainImagePreview(post.imageUrls[0]);
+      const additional = post.imageUrls.slice(1).map((url, idx) => ({
+        id: `server-${idx}`,
+        preview: url,
+        isFromServer: true,
+      }));
+      setAdditionalImages(additional);
+    }
+  }, [post]);
 
   const handleAdditionalImageUpload = (
     e: React.ChangeEvent<HTMLInputElement>
@@ -37,7 +54,7 @@ const WriteNewsPage: React.FC = () => {
         const reader = new FileReader();
         reader.onload = () => {
           // 첫 번째 사진이면 메인 사진으로 설정
-          if (!mainImage) {
+          if (!mainImagePreview) {
             setMainImage(file);
             setMainImagePreview(reader.result as string);
           } else {
@@ -48,7 +65,6 @@ const WriteNewsPage: React.FC = () => {
                 id: Date.now().toString(),
                 file,
                 preview: reader.result as string,
-                description: "",
               };
               setAdditionalImages((prev) => [...prev, newImage]);
             }
@@ -65,30 +81,47 @@ const WriteNewsPage: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!title.trim() || !mainImage) return;
+    if (!title.trim()) return;
 
     setIsSubmitting(true);
 
-    const imagesToUpload: File[] = [
-      mainImage,
-      ...additionalImages.map((img) => img.file),
-    ];
+    try {
+      const filesToUpload: File[] = [];
 
-    writePost(familyId, userId, title, description, imagesToUpload);
+      if (mainImage) filesToUpload.push(mainImage);
+      additionalImages.forEach((img) => {
+        if (img.file) filesToUpload.push(img.file);
+      });
 
-    setTimeout(() => {
-      setIsSubmitting(false);
+      const existingFiles = await Promise.all(
+        additionalImages
+          .filter((img) => img.isFromServer)
+          .map(async (img) => {
+            const res = await fetch(img.preview);
+            const blob = await res.blob();
+            const fileName = img.preview.split("/").pop() || "image.jpg";
+            return new File([blob], fileName, { type: blob.type });
+          })
+      );
+
+      const allFiles = [...filesToUpload, ...existingFiles];
+
+      await patchPosts(post.id, title, description, allFiles);
       navigate("/home");
-    }, 1000);
-  };
-
-  const handleBack = () => {
-    navigate("/home");
+    } catch (err) {
+      console.error("소식 수정 실패:", err);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
     <MainLayout>
-      <Header title="글쓰기" showBackButton onBackClick={handleBack} />
+      <Header
+        title="소식 수정"
+        showBackButton
+        onBackClick={() => navigate("/home")}
+      />
 
       <div className="p-4 space-y-6">
         {/* 제목 입력 필드 */}
@@ -97,7 +130,7 @@ const WriteNewsPage: React.FC = () => {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder="제목을 입력해주세요"
+            placeholder="제목을 입력하세요"
             className="w-full px-4 py-3 border border-white rounded-lg focus:outline-none focus:ring-2 focus:ring-[#018941] focus:border-[#018941] transition-colors duration-200 text-lg"
           />
         </div>
@@ -202,7 +235,7 @@ const WriteNewsPage: React.FC = () => {
               <textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                placeholder="이 사진은 어떤 사진 인가요? (최대 100자)"
+                placeholder={post.content}
                 maxLength={MAX_DESCRIPTION}
                 className="w-full px-4 py-3 border border-white rounded-lg focus:outline-none focus:ring-2 focus:ring-[#018941] focus:border-[#018941] transition-colors duration-200 text-lg resize-none"
                 rows={3}
@@ -249,6 +282,7 @@ const WriteNewsPage: React.FC = () => {
                 </button>
               </div>
             ))}
+
             {additionalImages.length < MAX_IMAGES - 1 && (
               <div className="w-20 h-20 bg-gray-100 border-2 border-dashed border-gray-300 rounded-lg flex items-center justify-center">
                 <input
@@ -281,22 +315,22 @@ const WriteNewsPage: React.FC = () => {
           </div>
         </div>
 
-        {/* 공유하기 버튼 */}
+        {/* 저장하기 버튼 */}
         <button
           onClick={handleSubmit}
           disabled={
             isSubmitting ||
             !title.trim() ||
-            !mainImage ||
+            (!mainImage && !mainImagePreview) ||
             description.length < MIN_DESCRIPTION
           }
           className="w-full bg-[#018941] text-white py-4 px-6 rounded-lg font-medium text-lg hover:bg-[#017a3a] disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors duration-200"
         >
-          {isSubmitting ? "공유 중..." : "공유하기"}
+          {isSubmitting ? "저장 중..." : "저장하기"}
         </button>
       </div>
     </MainLayout>
   );
 };
 
-export default WriteNewsPage;
+export default EditNewsPage;

--- a/src/pages/FamilyInvitePage.tsx
+++ b/src/pages/FamilyInvitePage.tsx
@@ -1,19 +1,25 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import Header from "../components/common/Header";
 import MainLayout from "../components/layout/MainLayout";
 import Button from "../components/common/Button";
+import { useFamilyStore } from "../stores/usefamilyStore";
 
 const FamilyInvitePage: React.FC = () => {
-  const navigate = useNavigate();
+  const inviteCode = useFamilyStore((state) => state.inviteCode);
 
-  /* 가족 구성원 프로필 편집 */
-  const handleEditProfile = () => {
-    navigate("/member/edit");
+  /* TODO: 카카오 초대하기 구현 필요 */
+  const handleKaKao = () => {};
+
+  /* 초대코드 복사하기 */
+  const handleCopyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteCode);
+      alert("초대코드가 복사되었습니다!");
+    } catch (err) {
+      console.error("복사 실패:", err);
+      alert("복사에 실패했습니다. 다시 시도해주세요.");
+    }
   };
-
-  /* 가족 구성원 초대 */
-  const handleInviteFamily = () => {};
 
   return (
     <MainLayout>
@@ -25,14 +31,14 @@ const FamilyInvitePage: React.FC = () => {
 
         <div className="bg-white rounded-lg p-4 shadow-sm mt-4 h-30 flex flex-col justify-center items-center">
           <p className="text-xl font-bold mb-4">가족 초대코드</p>
-          <p className="text-2xl font-bold">A B C D E F</p>
+          <p className="text-2xl font-bold">{inviteCode}</p>
         </div>
 
         <div className="flex gap-4 mt-4">
           <Button
             variant="primary"
             size="medium"
-            onClick={handleEditProfile}
+            onClick={handleCopyCode}
             className="flex-1"
           >
             초대코드 복사하기
@@ -41,7 +47,7 @@ const FamilyInvitePage: React.FC = () => {
           <Button
             variant="primary"
             size="medium"
-            onClick={handleEditProfile}
+            onClick={handleKaKao}
             className="flex-1"
           >
             카톡으로 초대하기

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import MainLayout from "../components/layout/MainLayout";
 import FeedHeader from "../components/feed/FeedHeader";
@@ -6,38 +6,94 @@ import FeedTabs from "../components/feed/FeedTabs";
 import FeedFilters from "../components/feed/FeedFilters";
 import PostCard from "../components/feed/PostCard";
 import Button from "../components/common/Button";
-import type { Post } from "../types/feed";
+import OpenBoxIcon from "../assets/icons/OpenBoxIcon";
+import Alert from "../components/common/Alert";
+import WarningIcon from "../assets/icons/WarningIcon";
+import Album from "../components/other/Album";
+import { getFamilyPosts, getPostDetails } from "../services/postsApi";
+import type { PostData } from "../types/post";
+import { useUserStore } from "../stores/useUserStore";
+import { usePostStore } from "../stores/usePostStore";
+import { mapPostDataToPost } from "../utils/postUtil";
+
+const dumyAlbum = [
+  {
+    name: "보라카이 여행",
+    coverImage: "https://placekitten.com/400/200",
+    items: [
+      { label: "게시글", value: "5" },
+      { label: "작성자", value: "김가족" },
+    ],
+  },
+  {
+    name: "제주도 여행",
+    images: [
+      "https://placekitten.com/200/200",
+      "https://placekitten.com/201/200",
+      "https://placekitten.com/200/201",
+      "https://placekitten.com/201/201",
+    ],
+    items: [
+      { label: "게시글", value: "8" },
+      { label: "작성자", value: "이가족" },
+    ],
+  },
+  {
+    name: "서울 여행",
+    images: [],
+    items: [
+      { label: "게시글", value: "8" },
+      { label: "작성자", value: "이가족" },
+    ],
+  },
+  {
+    name: "서울 나들이",
+    images: [
+      "https://placekitten.com/202/202",
+      "https://placekitten.com/203/203",
+    ],
+    items: [
+      { label: "게시글", value: "3" },
+      { label: "작성자", value: "박가족" },
+    ],
+  },
+];
 
 const HomePage: React.FC = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("소식함");
   const [activeFilter, setActiveFilter] = useState("전체");
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [isDeleteAlert, setIsDeleteAlert] = useState(false);
 
-  // TODO: 실제 데이터로 교체
-  const posts: Post[] = [
-    {
-      id: "1",
-      author: "구성원",
-      authorImage: "/api/placeholder/40/40",
-      timeAgo: "2시간 전",
-      title: "제목",
-      content: "게시글 내용 2줄\n두 번째 줄입니다",
-      likes: 5,
-      comments: 3,
-      isNew: true,
-    },
-    {
-      id: "2",
-      author: "구성원",
-      authorImage: "/api/placeholder/40/40",
-      timeAgo: "4시간 전",
-      title: "제목",
-      content: "게시글 내용 2줄\n두 번째 줄입니다",
-      likes: 3,
-      comments: 1,
-      isNew: true,
-    },
-  ];
+  const familyId = useUserStore((state) => state.familyId);
+  const postsData = usePostStore((state) => state.posts);
+  const setPosts = usePostStore((state) => state.setPosts);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const res = await getFamilyPosts(familyId);
+        console.log("가족 소식 API 응답:", res);
+
+        const detailedPosts: PostData[] = (
+          await Promise.all(
+            res.data.map(async (postSummary: PostData) => {
+              const detail = await getPostDetails(postSummary.id);
+              return detail.data;
+            })
+          )
+        ).flat();
+
+        setPosts(detailedPosts);
+        console.log("이것은 ", detailedPosts);
+      } catch (error) {
+        console.error("가족 소식 불러오기 실패", error);
+      }
+    };
+
+    fetchPosts();
+  }, [familyId]);
 
   const handleWriteNews = () => {
     navigate("/write-news");
@@ -48,39 +104,121 @@ const HomePage: React.FC = () => {
     console.log("댓글 전송:", { postId, message });
   };
 
+  /* TODO: 앨범 삭제 함수*/
+  const handleDeleteAlbum = () => {};
+  const posts = mapPostDataToPost(postsData);
+
   return (
     <MainLayout>
       <FeedHeader groupName="가족 이름" />
       <FeedTabs activeTab={activeTab} onTabChange={setActiveTab} />
-      <FeedFilters
-        activeFilter={activeFilter}
-        onFilterChange={setActiveFilter}
-        onWriteNews={handleWriteNews}
-      />
 
-      <div className="flex-1 bg-white relative">
-        {/* 게시물 목록 */}
-        <div className="space-y-4 px-4 pb-20">
-          {posts.map((post) => (
-            <PostCard
-              key={post.id}
-              post={post}
-              onCommentSend={handleCommentSend}
-            />
-          ))}
-        </div>
+      {/* 소식함 */}
+      {activeTab === "소식함" && (
+        <>
+          <FeedFilters
+            activeFilter={activeFilter}
+            onFilterChange={setActiveFilter}
+            onWriteNews={handleWriteNews}
+          />
 
-        {/* 플로팅 글쓰기 버튼 */}
-        <div className="fixed bottom-28 left-1/2 transform -translate-x-1/2 w-full max-w-md px-2 z-50">
-          <Button
-            variant="primary"
-            className="w-24 h-10 rounded-full shadow-lg flex items-center justify-center text-me"
-            onClick={handleWriteNews}
-          >
-            + 글쓰기
-          </Button>
-        </div>
-      </div>
+          <div className="flex-1 bg-white relative">
+            {/* 게시물 목록 */}
+            <div className="space-y-4 px-4 pb-20">
+              {posts.map((post) => (
+                <PostCard
+                  key={post.id}
+                  post={post}
+                  onCommentSend={handleCommentSend}
+                />
+              ))}
+            </div>
+
+            {/* 플로팅 글쓰기 버튼 */}
+            <div className="fixed bottom-28 left-1/2 transform -translate-x-1/2 w-full max-w-md z-50 flex justify-end">
+              <Button
+                variant="primary"
+                className="w-24 h-10 rounded-full shadow-lg flex items-center justify-center text-me"
+                onClick={handleWriteNews}
+              >
+                + 글쓰기
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 보관함 */}
+      {activeTab === "보관함" && (
+        <>
+          <div className="flex justify-end mt-4 relative">
+            <Button
+              variant="text"
+              size="small"
+              onClick={() => navigate("/home/album/pick")}
+            >
+              앨범 추가하기
+            </Button>
+
+            {dropdownOpen && (
+              <div className="absolute right-0 mt-2 w-40 bg-white shadow-lg rounded-lg border z-10">
+                <ul>
+                  {["앨범 정보", "앨범 편집", "삭제"].map((option) => (
+                    <li
+                      key={option}
+                      className={`px-4 py-2 cursor-pointer hover:bg-gray-100 ${
+                        option === "삭제" ? "text-red-500 hover:bg-red-100" : ""
+                      }`}
+                      onClick={() => setIsDeleteAlert(true)}
+                    >
+                      {option}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          {/* 더미 앨범 데이터 */}
+          {dumyAlbum && (
+            <div className="grid grid-cols-2 gap-4 mt-8 px-4">
+              {dumyAlbum.map((album, idx) => (
+                <Album
+                  key={idx}
+                  coverImage={album.coverImage}
+                  albumName={album.name}
+                  images={album.images}
+                  onDelete={() => setIsDeleteAlert(true)}
+                />
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-col items-center justify-center mt-14 text-gray-400">
+            <OpenBoxIcon className="w-30 h-30" />
+            <p className="text-center mt-8">
+              앗! <br />
+              보관함이 비어있어요
+            </p>
+          </div>
+        </>
+      )}
+
+      {/* 앨범 삭제 경고창 */}
+      {isDeleteAlert && (
+        <Alert
+          icon={<WarningIcon className="w-10 h-10 text-red-600" />}
+          message="정말 삭제하시겠어요?"
+          confirmText="제외하기"
+          confirmVariant="danger"
+          onConfirm={handleDeleteAlbum}
+          confirmClassName="flex-1 ml-4"
+          cancelText="취소"
+          cancelVariant="secondaryOutline"
+          cancelClassName="flex-1"
+          onCancel={() => setIsDeleteAlert(false)}
+        />
+      )}
     </MainLayout>
   );
 };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -135,7 +135,7 @@ const HomePage: React.FC = () => {
             </div>
 
             {/* 플로팅 글쓰기 버튼 */}
-            <div className="fixed bottom-28 left-1/2 transform -translate-x-1/2 w-full max-w-md z-50 flex justify-end">
+            <div className="fixed bottom-28 left-1/2 transform -translate-x-1/2 w-full max-w-md z-50 flex justify-center">
               <Button
                 variant="primary"
                 className="w-24 h-10 rounded-full shadow-lg flex items-center justify-center text-me"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -194,13 +194,15 @@ const HomePage: React.FC = () => {
             </div>
           )}
 
-          <div className="flex flex-col items-center justify-center mt-14 text-gray-400">
-            <OpenBoxIcon className="w-30 h-30" />
-            <p className="text-center mt-8">
-              앗! <br />
-              보관함이 비어있어요
-            </p>
-          </div>
+          {!dumyAlbum && (
+            <div className="flex flex-col items-center justify-center mt-14 text-gray-400">
+              <OpenBoxIcon className="w-30 h-30" />
+              <p className="text-center mt-8">
+                앗! <br />
+                보관함이 비어있어요
+              </p>
+            </div>
+          )}
         </>
       )}
 

--- a/src/pages/NewsDetailPage.tsx
+++ b/src/pages/NewsDetailPage.tsx
@@ -1,38 +1,46 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import MainLayout from "../components/layout/MainLayout";
 import Header from "../components/common/Header";
-import FeedTabs from "../components/feed/FeedTabs";
-import FeedFilters from "../components/feed/FeedFilters";
-import PostCard from "../components/feed/PostCard";
-import type { Post } from "../types/feed";
 import PostDetail from "../components/feed/PostDetail";
+import { useUserStore } from "../stores/useUserStore";
+import { usePostStore } from "../stores/usePostStore";
+import { mapPostDataToPost } from "../utils/postUtil";
+import { deletePost } from "../services/postsApi";
 
 const NewsDetailPage: React.FC = () => {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState("소식함");
-  const [activeFilter, setActiveFilter] = useState("전체");
 
-  // TODO: 실제 데이터로 교체
-  const post: Post = {
-    id: "1",
-    author: "구성원",
-    authorImage: "/api/placeholder/40/40",
-    timeAgo: "2시간 전",
-    title: "제목",
-    content: "게시글 내용 2줄\n두 번째 줄입니다",
-    likes: 5,
-    comments: 3,
-    isNew: true,
-  };
+  const { postId } = useParams<{ postId: string }>();
 
-  const handleWriteNews = () => {
-    navigate("/write-news");
-  };
+  const userId = useUserStore((state) => state.userId);
+  const postsData = usePostStore((state) => state.posts);
+  const posts = mapPostDataToPost(postsData);
 
-  const handleCommentSend = (postId: string, message: string) => {
+  const post = posts.find((p) => p.id && p.id.toString() === postId);
+
+  if (!post) {
+    return <div>게시글을 찾을 수 없습니다.</div>;
+  }
+  const handleCommentSend = (postId: number, message: string) => {
     // TODO: 댓글 전송 로직 구현
     console.log("댓글 전송:", { postId, message });
+  };
+
+  /* 게시글 삭제 함수 */
+  const handleDeletePost = async () => {
+    if (!postId) return;
+
+    const postIdNumber = Number(postId);
+    if (isNaN(postIdNumber)) return;
+
+    const response = await deletePost(postIdNumber);
+
+    if (response.success) {
+      navigate("/home");
+    } else {
+      alert("게시글 삭제에 실패하였습니다. " + response.message);
+    }
   };
 
   return (
@@ -44,9 +52,12 @@ const NewsDetailPage: React.FC = () => {
         {/* 게시물 목록 */}
         <div className="px-4 pb-24">
           <PostDetail
-            key={post.id}
             post={post}
+            isManager={
+              userId && post.authorId ? userId === post.authorId : false
+            }
             onCommentSend={handleCommentSend}
+            onDeletePost={handleDeletePost}
           />
         </div>
       </div>

--- a/src/pages/NewsDetailPage.tsx
+++ b/src/pages/NewsDetailPage.tsx
@@ -45,7 +45,11 @@ const NewsDetailPage: React.FC = () => {
 
   return (
     <MainLayout>
-      <Header title="소식 상세" />
+      <Header
+        title="소식 상세"
+        showBackButton
+        onBackClick={() => navigate("/home")}
+      />
 
       {/* 메인 콘텐츠 */}
       <div className="flex-1 bg-white">

--- a/src/pages/PaymentManagePage.tsx
+++ b/src/pages/PaymentManagePage.tsx
@@ -56,7 +56,7 @@ const PaymentManagePage: React.FC = () => {
         icon={
           <CardIcon
             className="w-20 mt-4"
-            style={{ color: selectedPayment.iconColor }} // 이렇게 동적으로 적용
+            style={{ color: selectedPayment.iconColor }}
           />
         }
         label={selectedPayment.label}

--- a/src/pages/PaymentManagePage.tsx
+++ b/src/pages/PaymentManagePage.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-
+import React, { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import Header from "../components/common/Header";
 import MainLayout from "../components/layout/MainLayout";
 import Button from "../components/common/Button";
@@ -8,50 +7,45 @@ import Alert from "../components/common/Alert";
 import WarningIcon from "../assets/icons/WarningIcon";
 import CardIcon from "../assets/icons/CardIcon";
 import PaymentInfo from "../components/other/PaymentInfo";
-
-const payments = [
-  {
-    id: 1,
-    label: "신한카드",
-    cardNumber: "**** - **** - **** - 1234",
-    date: "08/29",
-    isBasic: true,
-    icon: <CardIcon className="w-10 h-10 text-[#018941]" />,
-  },
-  {
-    id: 2,
-    label: "국민카드",
-    cardNumber: "**** - **** - **** - 5678",
-    isBasic: false,
-    icon: <CardIcon className="w-10 h-10 text-[#016b33]" />,
-  },
-  {
-    id: 3,
-    label: "카카오뱅크 카드",
-    cardNumber: "**** - **** - **** - 9012",
-    isBasic: false,
-    icon: <CardIcon className="w-10 h-10 text-[#feca1b]" />,
-  },
-];
+import { usePaymentStore } from "../stores/usePaymentStore";
+import type { Payment } from "../stores/usePaymentStore";
 
 const PaymentManagePage: React.FC = () => {
-  const payment = {
-    card: "**** - **** - **** - 3444",
-    date: "03/27",
-    isBasicPayment: true,
-  };
+  const { id } = useParams<{ id: string }>();
+  const payments = usePaymentStore((state) => state.payments);
+  const setPayments = usePaymentStore((state) => state.setPayments);
 
+  const [selectedPayment, setSelectedPayment] = useState<Payment | null>(null);
+  const [isBasicPayment, setIsBasicPayment] = useState(false);
   const navigate = useNavigate();
   const [isDeleteAlert, setIsDeleteAlert] = useState(false);
-  const [isBasicPayment, setIsBasicPayment] = useState(payment.isBasicPayment);
 
-  /* TODO: 사용자 정보 수정 후 저장하는 함수 수정 필요 */
+  useEffect(() => {
+    const payment = payments.find((p) => p.id === Number(id));
+    if (payment) {
+      setSelectedPayment(payment);
+      setIsBasicPayment(payment.isBasic);
+    }
+  }, [id, payments]);
+
+  if (!selectedPayment) return null;
+
   const handleSave = () => {
+    const updatedPayments = payments.map((p) =>
+      p.id === selectedPayment.id
+        ? { ...p, isBasic: isBasicPayment }
+        : { ...p, isBasic: false }
+    );
+    setPayments(updatedPayments);
     navigate("/home");
   };
 
-  /* TODO: 결제수단 삭제하는 로직 함수 추가 필요*/
-  const handleDeletePayment = () => {};
+  const handleDeletePayment = () => {
+    const updatedPayments = payments.filter((p) => p.id !== selectedPayment.id);
+    setPayments(updatedPayments);
+    setIsDeleteAlert(false);
+    navigate("/home");
+  };
 
   return (
     <MainLayout>
@@ -59,13 +53,17 @@ const PaymentManagePage: React.FC = () => {
 
       <PaymentInfo
         type="card"
-        icon={<CardIcon className="w-20 text-[#018941] mt-4" />}
-        label={payments[0].cardNumber}
-        cardNumber={payments[0].cardNumber}
-        date={payments[0].date}
+        icon={
+          <CardIcon
+            className="w-20 mt-4"
+            style={{ color: selectedPayment.iconColor }} // 이렇게 동적으로 적용
+          />
+        }
+        label={selectedPayment.label}
+        cardNumber={selectedPayment.cardNumber}
+        date={selectedPayment.date}
       />
 
-      {/* 기본 결제 수단 수정 */}
       <div className="p-4 flex flex-col space-y-10">
         <div className="flex items-center space-x-2">
           <input
@@ -77,13 +75,12 @@ const PaymentManagePage: React.FC = () => {
           <p>기본 결제 수단으로 지정할래요</p>
         </div>
 
-        {/* 버튼 영역 */}
         <div className="flex gap-4 mt-10">
           <Button
             type="button"
             variant="primary"
             size="medium"
-            onClick={() => handleSave}
+            onClick={handleSave}
             className="flex-1"
           >
             저장하기

--- a/src/services/booksApi.ts
+++ b/src/services/booksApi.ts
@@ -1,0 +1,88 @@
+import axios from "axios";
+
+export interface BookData {
+  id: number;
+  familyId: number;
+  name: string;
+  pdfUrl: string;
+  imageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BookResponse {
+  success: boolean;
+  data: BookData | BookData[] | {};
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
+/* GET - 소식 책자 단건 */
+export const getBooks = async (id: number) => {
+  try {
+    const response = await api.get<BookResponse>(`familes/${id}/book`);
+    console.log(response.data);
+    console.log("[GET] 소식 책자 단건: ", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[GET] 소식 책자 단건 에러", error);
+    throw error;
+  }
+};
+
+/* POST - 소식 책자 생성 */
+export const postBooks = async (familyId: number, name: string, file: File) => {
+  try {
+    const formData = new FormData();
+    formData.append("name", name);
+    formData.append("file", file);
+
+    const response = await api.post<BookResponse>(
+      `/families/${familyId}/book}`,
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+
+    console.log("[POST] 소식 책자 등록 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[POST] 북 등록 에러:", error);
+    throw error;
+  }
+};
+
+/* PATCH - 소식 책자 이름 변경 */
+export const patchPostName = async (bookId: number, name: string) => {
+  try {
+    const payload = { bookId, name };
+    const response = await api.patch<BookResponse>(`/families/book`, payload);
+
+    console.log("[PATCH] 책자 이름 변경 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[PATCH] 책자 이름 변경 에러:", error);
+    throw error;
+  }
+};
+
+/* GET - 소식 책자 목록 */
+export const getBookList = async (id: number) => {
+  try {
+    const response = await api.get<BookResponse>(`familes/${id}/books`);
+    console.log(response.data);
+    console.log("[GET] 소식 책자 목록: ", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[GET] 소식 책자 목록 에러", error);
+    throw error;
+  }
+};

--- a/src/services/familyApi.ts
+++ b/src/services/familyApi.ts
@@ -1,0 +1,265 @@
+import axios from "axios";
+
+export interface FamilyData {
+  familyId: number;
+  familyName: string;
+  familyProfileImageUrl: string;
+  monthlyDeadline: number;
+  inviteCode: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FamilyInvite {
+  familyId: number;
+  familyName: string;
+  inviteCode: string;
+}
+
+export interface InvitationData {
+  id: number;
+  inviteCode: string;
+  invitedUserId: number;
+  status: string;
+  expiresAt: string;
+  createdAt: string;
+  acceptedAt: string | null;
+}
+
+export interface FamilyMemberData {
+  id: number;
+  userId: number;
+  name: string;
+  profileImageUrl: string;
+  relationship: string;
+  role: string;
+}
+
+export interface FamilyInvitationRequestData {
+  invitationId: number;
+  userId: number;
+  name: string;
+  profileImageUrl: string;
+  requestedAt: string;
+}
+
+export interface FamilyDetailData {
+  familyId: number;
+  familyName: string;
+  familyProfileImageUrl: string;
+  monthlyDeadline: number;
+  inviteCode: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FamilyDetailResponse {
+  success: boolean;
+  data: FamilyDetailData;
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+/* 각 API별 Response 타입 */
+export interface FamilyDataResponse {
+  success: boolean;
+  data: FamilyData;
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+export interface FamilyInviteResponse {
+  success: boolean;
+  data: FamilyInvite;
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+export interface InvitationDataResponse {
+  success: boolean;
+  data: InvitationData;
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+export interface FamilyMembersResponse {
+  success: boolean;
+  data: FamilyMemberData[];
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+export interface FamilyInvitationRequestsResponse {
+  success: boolean;
+  data: FamilyInvitationRequestData[];
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+export interface FamilyDetailResponse {
+  success: boolean;
+  data: FamilyDetailData;
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+export interface EmptyDataResponse {
+  success: boolean;
+  data: {};
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
+/* POST - 초대 발급 */
+export const inviteFamily = async (id: number) => {
+  try {
+    const response = await api.post<FamilyInviteResponse>(
+      `/families/${id}/members/invite`
+    );
+    console.log(response.data);
+    console.log("[POST] 초대 발급 성공 ", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[POST] 초대 발급 에러 ", error);
+    throw error;
+  }
+};
+
+/* POST - 초대 수락 */
+export const approveInvitation = async (
+  id: number,
+  invitationId: number,
+  relationship: string
+) => {
+  try {
+    const payload = {
+      invitationId: invitationId,
+      relationship: relationship,
+    };
+    const response = await api.post<FamilyInviteResponse>(
+      `/families/${id}/invitations/approve`,
+      payload
+    );
+    console.log(response.data);
+    console.log("[POST] 초대 승인 성공 ", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[POST] 초대 승인 에러 ", error);
+    throw error;
+  }
+};
+
+/* POST - 초대 참여 */
+export const joinInvitation = async (inviteCode: string, userId: number) => {
+  try {
+    const payload = { inviteCode: inviteCode, userId: userId };
+    const response = await api.post<FamilyDataResponse>(
+      `/families/members/join`,
+      payload
+    );
+
+    console.log("[POST] 초대 참여 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[POST] 초대 참여 에러:", error);
+    throw error;
+  }
+};
+
+/* POST - 초대 거부 */
+export const rejectInvitation = async (invitationId: number) => {
+  try {
+    const response = await api.post<InvitationDataResponse>(
+      `/families/invitations/${invitationId}/reject`
+    );
+
+    console.log("[POST] 초대 거부 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[POST] 초대 거부 에러:", error);
+    throw error;
+  }
+};
+
+/* GET - 멤버 목록 (리더용) */
+export const getMembersList = async (id: number) => {
+  try {
+    const response = await api.get<FamilyMembersResponse>(
+      `/families/${id}/members`
+    );
+
+    console.log("[GET] 멤버 목록 (리더용) 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[GET] 멤버 목록 (리더용) 에러:", error);
+    throw error;
+  }
+};
+
+/* GET - 초대 요청 목록 */
+export const getInvitations = async (id: number) => {
+  try {
+    const response = await api.get<FamilyInvitationRequestsResponse>(
+      `/families/${id}/invitations/pending`
+    );
+
+    console.log("[GET] 초대 요청 목록 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[GET] 초대 요청 목록 에러:", error);
+    throw error;
+  }
+};
+
+/* GET - 가족 단건 조회 */
+export const getUser = async (userId: number) => {
+  try {
+    const response = await api.get<FamilyDetailResponse>(
+      `/families/user/${userId}`
+    );
+
+    if (!response.data.success || !response.data.data) {
+      console.warn("[GET] 가족 단건 조회: 데이터 없음", response.data);
+      return null;
+    }
+
+    console.log("[GET] 가족 단건 조회 성공:", response.data.data);
+    return response.data.data as FamilyDetailData;
+  } catch (error: any) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      console.warn("[GET] 가족 단건 조회 실패: 미존재 리소스");
+      return null;
+    }
+    console.error("[GET] 가족 단건 조회 에러:", error);
+    throw error;
+  }
+};
+
+/* DELETE - 멤버 내보내기 */
+export const deleteMember = async (id: number, userId: number) => {
+  try {
+    const response = await api.delete<EmptyDataResponse>(
+      `/families/${id}/members/${userId}`
+    );
+
+    console.log("[DELETE] 멤버 내보내기 성공:", response.data.data);
+    return response.data;
+  } catch (error: any) {
+    console.error("[DELETE] 멤버 내보내기 에러:", error);
+    throw error;
+  }
+};

--- a/src/services/fileApi.ts
+++ b/src/services/fileApi.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+
+interface FileUploadData {
+  [key: string]: string;
+}
+
+export interface FileUploadResponse {
+  success: boolean;
+  data: FileUploadData;
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
+/* POST - 이미지 업로드 */
+export const uploadImage = async (file: File) => {
+  try {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const response = await api.post<FileUploadResponse>(`/files`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+
+    console.log("[POST] 이미지 업로드 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[POST] 이미지 업로드 에러:", error);
+    throw error;
+  }
+};

--- a/src/services/postsApi.ts
+++ b/src/services/postsApi.ts
@@ -1,0 +1,109 @@
+import axios from "axios";
+import type { PostResponse } from "../types/post";
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
+/* GET - 그룹 소식 목록 */
+export const getFamilyPosts = async (id: number) => {
+  try {
+    const response = await api.get<PostResponse>(`familes/${id}/posts`);
+    console.log("[GET] 그룹 소식 목록: ", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[GET] 그룹 소식 목록 에러", error);
+    throw error;
+  }
+};
+
+/* POST - 소식 작성 */
+export const writePost = async (
+  familyId: number,
+  userId: number,
+  title: string,
+  content?: string,
+  images?: File[]
+) => {
+  const formData = new FormData();
+  formData.append("userId", String(userId));
+  formData.append("title", title);
+  if (content) formData.append("content", content);
+
+  if (images && images.length > 0) {
+    images.forEach((img) => formData.append("images", img));
+  }
+
+  try {
+    const response = await api.post<PostResponse>(
+      `/familes/${familyId}/posts`,
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+    console.log("[POST] 게시글 등록 성공: ", response.data);
+    return response.data;
+  } catch (error) {
+    console.log("[POST] 게시글 등록 에러", error);
+  }
+};
+
+/* GET - 소식 상세 */
+export const getPostDetails = async (id: number) => {
+  try {
+    const response = await api.get<PostResponse>(`/posts/${id}`);
+    console.log("[GET] 소식 상세: ", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[GET] 소식 상세 에러", error);
+    throw error;
+  }
+};
+
+/* DELETE - 소식 삭제 */
+export const deletePost = async (id: number) => {
+  try {
+    const response = await api.delete<PostResponse>(`/posts/${id}`);
+    console.log(response.data);
+    console.log("[DELETE] 소식 삭제: ", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[DELETE] 소식 삭제 에러", error);
+    throw error;
+  }
+};
+
+/* POST - 소식 수정 */
+export const patchPosts = async (
+  id: number,
+  title: string,
+  content?: string,
+  images?: File[]
+) => {
+  const formData = new FormData();
+
+  formData.append("title", title);
+  if (content) formData.append("content", content);
+  if (images && images.length > 0) {
+    images.forEach((image) => {
+      formData.append("images", image);
+    });
+  }
+
+  try {
+    const response = await api.patch<PostResponse>(`/posts/${id}`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+
+    console.log("[PATCH] 소식 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("[PATCH] 소식 수정 에러:", error);
+    throw error;
+  }
+};

--- a/src/stores/useFamilyStore.ts
+++ b/src/stores/useFamilyStore.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+
+export interface FamilyMember {
+  invitationId: number;
+  userId: number;
+  name: string;
+  profileImageUrl: string;
+  requestedAt: string;
+}
+
+interface FamilyState {
+  inviteCode: string;
+  invitedFamilyMembers: FamilyMember[];
+  setInviteCode: (code: string) => void;
+  setInvitedFamilyMembers: (members: FamilyMember[]) => void;
+}
+
+export const useFamilyStore = create<FamilyState>((set) => ({
+  inviteCode: "",
+  invitedFamilyMembers: [
+    {
+      invitationId: 101,
+      userId: 1,
+      name: "김아빠",
+      profileImageUrl: "/api/placeholder/80/80",
+      requestedAt: "2025-08-24T12:00:00.000Z",
+    },
+    {
+      invitationId: 102,
+      userId: 2,
+      name: "이엄마",
+      profileImageUrl: "/api/placeholder/80/80",
+      requestedAt: "2025-08-24T12:05:00.000Z",
+    },
+    {
+      invitationId: 103,
+      userId: 3,
+      name: "김동생",
+      profileImageUrl: "/api/placeholder/80/80",
+      requestedAt: "2025-08-24T12:10:00.000Z",
+    },
+  ],
+  setInviteCode: (code) => set({ inviteCode: code }),
+  setInvitedFamilyMembers: (members) => set({ invitedFamilyMembers: members }),
+}));

--- a/src/stores/usePaymentStore.ts
+++ b/src/stores/usePaymentStore.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+
+export interface Payment {
+  id: number;
+  label: string;
+  cardNumber: string;
+  isBasic: boolean;
+  iconColor: string;
+  date: string;
+}
+
+interface PaymentState {
+  payments: Payment[];
+  inviteCode: string;
+  setPayments: (payments: Payment[]) => void;
+}
+
+export const usePaymentStore = create<PaymentState>((set) => ({
+  inviteCode: "",
+  payments: [
+    {
+      id: 1,
+      label: "신한카드",
+      cardNumber: "**** - **** - **** - 1234",
+      isBasic: true,
+      iconColor: "#018941",
+      date: "08/29",
+    },
+    {
+      id: 2,
+      label: "국민카드",
+      cardNumber: "**** - **** - **** - 5678",
+      isBasic: false,
+      iconColor: "#016b33",
+      date: "09/10",
+    },
+    {
+      id: 3,
+      label: "카카오뱅크 카드",
+      cardNumber: "**** - **** - **** - 9012",
+      isBasic: false,
+      iconColor: "#feca1b",
+      date: "09/15",
+    },
+  ],
+  setPayments: (payments) => set({ payments }),
+}));

--- a/src/stores/usePaymentStore.ts
+++ b/src/stores/usePaymentStore.ts
@@ -11,12 +11,10 @@ export interface Payment {
 
 interface PaymentState {
   payments: Payment[];
-  inviteCode: string;
   setPayments: (payments: Payment[]) => void;
 }
 
 export const usePaymentStore = create<PaymentState>((set) => ({
-  inviteCode: "",
   payments: [
     {
       id: 1,

--- a/src/stores/usePostStore.ts
+++ b/src/stores/usePostStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+import type { PostData } from "../types/post";
+
+interface PostState {
+  posts: PostData[];
+  setPosts: (posts: PostData[]) => void;
+  addPost: (post: PostData) => void;
+  updatePost: (id: number, updatedPost: Partial<PostData>) => void;
+  removePost: (id: number) => void;
+}
+
+export const usePostStore = create<PostState>((set) => ({
+  posts: [],
+  setPosts: (posts) => set({ posts }),
+  addPost: (post) => set((state) => ({ posts: [post, ...state.posts] })),
+  updatePost: (id, updatedPost) =>
+    set((state) => ({
+      posts: state.posts.map((p) =>
+        p.id === id ? { ...p, ...updatedPost } : p
+      ),
+    })),
+  removePost: (id) =>
+    set((state) => ({
+      posts: state.posts.filter((p) => p.id !== id),
+    })),
+}));

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+interface UserState {
+  familyId: number;
+  userId: number;
+  userName?: string;
+  userEmail?: string;
+  userProfileImageUrl?: string;
+  familyName: string;
+  familyProfileImageUrl: string;
+  monthlyDeadline: number;
+  status: string;
+  setUserState: (state: Partial<UserState>) => void;
+}
+
+export const useUserStore = create<UserState>((set) => ({
+  familyId: 47,
+  userId: 5,
+  userName: "김가족",
+  userEmail: "family@example.com",
+  userProfileImageUrl: "",
+  familyName: "",
+  familyProfileImageUrl: "",
+  monthlyDeadline: 0,
+  status: "",
+  setUserState: (state) => set((prev) => ({ ...prev, ...state })),
+}));

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -1,11 +1,12 @@
 export interface Post {
-  id: string;
+  id: number;
+  authorId?: number;
   author: string;
   authorImage: string;
   timeAgo: string;
   title: string;
   content: string;
-  imageUrl?: string;
+  imageUrls?: string[];
   likes: number;
   comments: number;
   isNew: boolean;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,25 @@
+export interface PostImage {
+  id: number;
+  imageUrl: string;
+  imageOrder: number;
+}
+
+export interface PostData {
+  id: number;
+  familyId: number;
+  userId: number;
+  title: string;
+  content: string;
+  postMonth: string;
+  createdAt: string;
+  updatedAt: string;
+  images: PostImage[];
+}
+
+export interface PostResponse {
+  success: boolean;
+  data: PostData[];
+  message: string;
+  errorCode: string | null;
+  timestamp: string;
+}

--- a/src/utils/postUtil.ts
+++ b/src/utils/postUtil.ts
@@ -1,0 +1,20 @@
+import type { PostData } from "../types/post";
+import type { Post } from "../types/feed";
+
+const BASIC_URL = import.meta.env.VITE_IMAGE_BASE_URL;
+
+export const mapPostDataToPost = (data: PostData[]): Post[] => {
+  return data.map((p) => ({
+    id: p.id.toString(),
+    author: "김가족",
+    authorId: 5,
+    authorImage: "",
+    timeAgo: new Date(p.createdAt).toLocaleDateString(),
+    title: p.title,
+    content: p.content,
+    imageUrls: p.images.map((img) => `${BASIC_URL}${img.imageUrl}`),
+    likes: 7,
+    comments: 5,
+    isNew: true,
+  }));
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
-    port: 4000,
+    port: 3000,
+    strictPort: true,
   },
 });


### PR DESCRIPTION
## 🚀 Background
- 보관함 UI 구현
- 소식/가족 관련 페이지와 API 일부 연동
- 자동 결제 관리, 상자/카드/경고 아이콘 추가
- 상태 관리(zustand) 및 유틸 함수 추가

## 🥥 Changes
- Header 컴포넌트 중복 title 제거
- 뒤로가기 버튼 위치 및 기능 수정
- 보관함 페이지 UI 수정, 글쓰기 버튼 중앙 정렬
 -가족/소식 관련 페이지 API 연동 및 상태 관리 추가
 -책자 API, 이미지 API, 유틸 함수 추가
 -아이콘(상자, 카드, 경고) 컴포넌트 추가

## 🧪 Testing (API)
- ✅ : 작동 및 연동 확인
- ❌ : 연동 X
- ⛔️ : 연동 완료했으나 페이지가 없어서 확인 불가

**Posts API TEST**
✅ GET - 그룹 소식 목록
✅ POST - 소식 목록 작성
✅ GET - 소식 상세
✅ DELETE - 소식 삭제
✅ PATCH - 소식 수정

**Family API TEST**
❌ POST - 가족 생성
✅ POST - 초대 발급
❌ POST - 초대 승인
⛔️ POST - 초대 참여
⛔️ POST - 초대 거부
GET - 가족 단건 조회
❌ DELETE - 멤버 내보내기

**안내**
- 앨범 API는 없어서 기본 이미지로만 넣어놨습니다.

## 📸 Screenshots
- 용량 문제로 9배속
https://github.com/user-attachments/assets/8eef0403-f324-4dc7-876b-ce6444c47eb3

## ⚓ Related Issue
- closes #12 